### PR TITLE
feat(GradingSession): add session API + tests (slice 1 of #6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,3 +143,17 @@ is in .gitignore so any record will need be in a summary file in design_history/
 - If I ask you to do something that is more than a simple fix or refinement, and you have
 multiple questions or feel you need clarification, please pose this as a questionnaire file
 for me to answer in.
+
+## Agent skills
+
+### Issue tracker
+
+GitHub Issues at `SartorialOffense/Dotsesses` via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Five canonical labels — names match the canonical roles. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout: `CONTEXT.md` and `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -91,6 +91,13 @@ the slot collection so item identity is preserved across moves (no
 ItemsControl rebuild churn). Slots are read-only from the binding
 side — mutations go through the GradingSession's API.
 
+The **structural catch-all** Grade — the lowest-Order Grade in the
+session's initial cutoffs — has *no* CutoffSlot. It is always
+implicitly enabled, never draggable, and acts purely as a fallback
+for `GradeAssigner` (see ADR-0011). Calls to `MoveCutoff`,
+`EnableGrade`, or `DisableGrade` against the catch-all throw
+`ArgumentException`.
+
 **GradeBin**: The vertical stack of dots in the dotplot at one
 AggregateScore value. Students sharing an AggregateScore stack into the
 same GradeBin.

--- a/Dotsesses.Tests/Fixtures/TestFixtures.cs
+++ b/Dotsesses.Tests/Fixtures/TestFixtures.cs
@@ -1,0 +1,64 @@
+namespace Dotsesses.Tests.Fixtures;
+
+using Dotsesses.Calculators;
+using Dotsesses.Models;
+using Dotsesses.UI;
+
+/// <summary>
+/// Builders for a predictable ClassAssessment + GradingSession used
+/// across GradingSessionTests. The fixture is deliberately minimal —
+/// add knobs only when a test needs them.
+/// </summary>
+public static class TestFixtures
+{
+    public static readonly Grade GradeA = new(LetterGrade.A, 0);
+    public static readonly Grade GradeB = new(LetterGrade.B, 3);
+    public static readonly Grade GradeC = new(LetterGrade.C, 6);
+    public static readonly Grade GradeF = new(LetterGrade.F, 10);
+
+    /// <summary>
+    /// 50 students with AggregateGrades 50, 60, …, 540 (linear) and a
+    /// tight curve A=10 / B=20 / C=20 / F=0-0. The curve filter drops
+    /// F, so InitialCutoffCalculator places A=450, B=250, C=50 — making
+    /// C the structural catch-all and Slots = [A, B].
+    /// </summary>
+    public static ClassAssessment ClassAssessmentForGrading()
+    {
+        var assessments = Enumerable.Range(0, 50)
+            .Select(i => new StudentAssessment(
+                id: i + 1,
+                scores: new[] { new Score("Total", null, 50 + i * 10) },
+                attributes: Array.Empty<StudentAttribute>(),
+                muppetName: $"Muppet{i + 1}"))
+            .ToList();
+
+        var defaultCurve = new[]
+        {
+            new CutoffCountRange(GradeA, 10, 10),
+            new CutoffCountRange(GradeB, 20, 20),
+            new CutoffCountRange(GradeC, 20, 20),
+            new CutoffCountRange(GradeF, 0, 0),
+        };
+
+        // ClassAssessment ctor still requires non-null currentCutoffs and
+        // current today; the session computes its own initial state from
+        // DefaultCurve and Assessments, so these placeholders are unused.
+        var placeholderCutoffs = new[] { new GradeCutoff(GradeC, 0) };
+        var placeholderCounts = new[] { new CutoffCount(GradeC, 0) };
+
+        return new ClassAssessment(
+            assessments: assessments,
+            currentCutoffs: placeholderCutoffs,
+            defaultCurve: defaultCurve,
+            current: placeholderCounts,
+            muppetNameMap: new Dictionary<int, MuppetNameInfo>(),
+            seriesColorMap: new Dictionary<string, string>());
+    }
+
+    public static GradingSession SessionForGrading() => new(
+        ClassAssessmentForGrading(),
+        new CursorPlacementCalculator(),
+        new CursorValidation(),
+        new CutoffCountCalculator(),
+        new InitialCutoffCalculator());
+}

--- a/Dotsesses.Tests/UI/GradingSessionTests.cs
+++ b/Dotsesses.Tests/UI/GradingSessionTests.cs
@@ -1,0 +1,373 @@
+namespace Dotsesses.Tests.UI;
+
+using Dotsesses.Models;
+using Dotsesses.Tests.Fixtures;
+using Dotsesses.UI;
+
+public class GradingSessionTests
+{
+    [Fact]
+    public void MoveCutoff_WithValidScore_CommitsAndBroadcasts()
+    {
+        // Arrange
+        var session = TestFixtures.SessionForGrading();
+        var originator = new object();
+        var slotA = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.A);
+        var slotB = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.B);
+        var midwayBetweenAandB = (slotA.Score + slotB.Score) / 2;
+
+        // Act
+        var result = session.MoveCutoff(slotB.Grade, midwayBetweenAandB, originator);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.Null(result.Failure);
+        Assert.Equal(
+            midwayBetweenAandB,
+            session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.B).Score);
+        Assert.True(session.LastChange.IsFrom(originator));
+    }
+
+    [Fact]
+    public void MoveCutoff_ToSameScoreAsAdjacentSlot_FailsWithWouldOverlap()
+    {
+        // Arrange
+        var session = TestFixtures.SessionForGrading();
+        var slotA = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.A);
+        var slotB = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.B);
+        var stateBefore = session.LastChange.State;
+
+        // Act — move A down to B's exact score (would collide)
+        var result = session.MoveCutoff(slotA.Grade, slotB.Score, new object());
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Equal(CutoffMoveFailure.WouldOverlap, result.Failure);
+        Assert.Same(stateBefore, session.LastChange.State);
+        Assert.Equal(450, slotA.Score);  // unchanged
+    }
+
+    [Fact]
+    public void MoveCutoff_PastAdjacentSlot_FailsWithOrderingViolation()
+    {
+        // Arrange
+        var session = TestFixtures.SessionForGrading();
+        var slotA = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.A);
+        var slotB = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.B);
+        var stateBefore = session.LastChange.State;
+
+        // Act — move A below B's score (A.Order < B.Order means A.Score must stay > B.Score)
+        var result = session.MoveCutoff(slotA.Grade, slotB.Score - 50, new object());
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Equal(CutoffMoveFailure.OrderingViolation, result.Failure);
+        Assert.Same(stateBefore, session.LastChange.State);
+    }
+
+    [Fact]
+    public void MoveCutoff_AboveMaxAggregatePlusMargin_FailsWithOutOfRange()
+    {
+        // Arrange — fixture: AggregateGrades 50..540 → max + 12 = 552
+        var session = TestFixtures.SessionForGrading();
+        var slotA = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.A);
+        var stateBefore = session.LastChange.State;
+
+        // Act — move A to 600 (well outside the upper bound)
+        var result = session.MoveCutoff(slotA.Grade, 600, new object());
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Equal(CutoffMoveFailure.OutOfRange, result.Failure);
+        Assert.Same(stateBefore, session.LastChange.State);
+    }
+
+    [Fact]
+    public void MoveCutoff_BelowMinAggregateMinusMargin_FailsWithOutOfRange()
+    {
+        // Arrange — fixture: AggregateGrades 50..540 → min − 12 = 38
+        var session = TestFixtures.SessionForGrading();
+        var slotB = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.B);
+        var stateBefore = session.LastChange.State;
+
+        // Act — move B to 0 (below the lower bound)
+        var result = session.MoveCutoff(slotB.Grade, 0, new object());
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Equal(CutoffMoveFailure.OutOfRange, result.Failure);
+        Assert.Same(stateBefore, session.LastChange.State);
+    }
+
+    [Fact]
+    public void MoveCutoff_OnStructuralCatchAll_ThrowsArgumentException()
+    {
+        // Arrange — in this fixture C is the structural catch-all (lowest Order in initial cutoffs)
+        var session = TestFixtures.SessionForGrading();
+
+        // Act & Assert — caller is asking for something the API doesn't support
+        Assert.Throws<ArgumentException>(() =>
+            session.MoveCutoff(TestFixtures.GradeC, 100, new object()));
+    }
+
+    [Fact]
+    public void LastChange_IsFrom_DistinguishesOriginatorFromOthersAndNull()
+    {
+        var session = TestFixtures.SessionForGrading();
+        var originator = new object();
+        var someoneElse = new object();
+        var slotB = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.B);
+
+        session.MoveCutoff(slotB.Grade, slotB.Score + 5, originator);
+
+        Assert.True(session.LastChange.IsFrom(originator));
+        Assert.False(session.LastChange.IsFrom(someoneElse));
+        Assert.False(session.LastChange.IsFrom(null));
+    }
+
+    [Fact]
+    public void CanMoveCutoff_WithValidScore_ReturnsOkAndDoesNotMutate()
+    {
+        var session = TestFixtures.SessionForGrading();
+        var slotB = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.B);
+        var initialScore = slotB.Score;
+        var stateBefore = session.LastChange.State;
+
+        var result = session.CanMoveCutoff(slotB.Grade, initialScore + 10);
+
+        Assert.True(result.Success);
+        Assert.Equal(initialScore, slotB.Score);
+        Assert.Same(stateBefore, session.LastChange.State);
+    }
+
+    [Fact]
+    public void CanMoveCutoff_WithInvalidScore_ReturnsFailureAndDoesNotMutate()
+    {
+        var session = TestFixtures.SessionForGrading();
+        var slotA = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.A);
+        var slotB = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.B);
+        var stateBefore = session.LastChange.State;
+
+        var result = session.CanMoveCutoff(slotA.Grade, slotB.Score);
+
+        Assert.False(result.Success);
+        Assert.Equal(CutoffMoveFailure.WouldOverlap, result.Failure);
+        Assert.Same(stateBefore, session.LastChange.State);
+    }
+
+    [Fact]
+    public void DisableGrade_FlagsSlotAndRemovesFromEnabledGrades()
+    {
+        var session = TestFixtures.SessionForGrading();
+        var slotB = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.B);
+        var stateBefore = session.LastChange.State;
+
+        session.DisableGrade(slotB.Grade);
+
+        Assert.False(slotB.IsEnabled);
+        Assert.DoesNotContain(slotB.Grade, session.CurrentState.EnabledGrades);
+        Assert.NotSame(stateBefore, session.LastChange.State);
+    }
+
+    [Fact]
+    public void DisableGrade_EmitsExactlyOneLastChange()
+    {
+        var session = TestFixtures.SessionForGrading();
+        var slotB = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.B);
+        var lastChangeFires = 0;
+        session.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(GradingSession.LastChange)) lastChangeFires++;
+        };
+
+        session.DisableGrade(slotB.Grade);
+
+        Assert.Equal(1, lastChangeFires);
+    }
+
+    [Fact]
+    public void MoveCutoff_OnDisabledGrade_FailsWithGradeNotEnabled()
+    {
+        var session = TestFixtures.SessionForGrading();
+        var slotB = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.B);
+        session.DisableGrade(slotB.Grade);
+
+        var result = session.MoveCutoff(slotB.Grade, slotB.Score + 5, new object());
+
+        Assert.False(result.Success);
+        Assert.Equal(CutoffMoveFailure.GradeNotEnabled, result.Failure);
+    }
+
+    [Fact]
+    public void EnableGrade_AfterDisable_PlacesAtMidpointBetweenEnabledNeighbors()
+    {
+        // Arrange — move A first so the midpoint is unambiguous.
+        // After move: A=400, B=250 (current), C=50 (catch-all).
+        // After disable B + re-enable: B should reseed via PlaceNewCursor → midpoint(A,C) = (400+50)/2 = 225.
+        var session = TestFixtures.SessionForGrading();
+        var slotA = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.A);
+        var slotB = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.B);
+
+        session.MoveCutoff(slotA.Grade, 400, new object());
+        session.DisableGrade(slotB.Grade);
+        session.EnableGrade(slotB.Grade);
+
+        Assert.True(slotB.IsEnabled);
+        Assert.Equal(225, slotB.Score);
+        Assert.Contains(slotB.Grade, session.CurrentState.EnabledGrades);
+    }
+
+    [Fact]
+    public void EnableGrade_EmitsExactlyOneLastChange()
+    {
+        var session = TestFixtures.SessionForGrading();
+        var slotB = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.B);
+
+        session.DisableGrade(slotB.Grade);
+
+        var lastChangeFires = 0;
+        session.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(GradingSession.LastChange)) lastChangeFires++;
+        };
+
+        session.EnableGrade(slotB.Grade);
+
+        Assert.Equal(1, lastChangeFires);
+    }
+
+    [Fact]
+    public void DisableGrade_OnStructuralCatchAll_ThrowsArgumentException()
+    {
+        var session = TestFixtures.SessionForGrading();
+
+        Assert.Throws<ArgumentException>(() =>
+            session.DisableGrade(TestFixtures.GradeC));
+    }
+
+    [Fact]
+    public void EnableGrade_OnStructuralCatchAll_ThrowsArgumentException()
+    {
+        var session = TestFixtures.SessionForGrading();
+
+        Assert.Throws<ArgumentException>(() =>
+            session.EnableGrade(TestFixtures.GradeC));
+    }
+
+    [Fact]
+    public void LoadCutoffs_HydratesSlotScoresAndEnabledGrades_EmitsOneLastChangeWithNullOriginator()
+    {
+        var session = TestFixtures.SessionForGrading();
+        var saved = new List<GradeCutoff>
+        {
+            new(TestFixtures.GradeA, 420),
+            new(TestFixtures.GradeB, 220),
+            new(TestFixtures.GradeC, 60),
+        };
+        var enabledGrades = new HashSet<Grade>
+        {
+            TestFixtures.GradeA, TestFixtures.GradeB, TestFixtures.GradeC,
+        };
+
+        var lastChangeFires = 0;
+        session.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(GradingSession.LastChange)) lastChangeFires++;
+        };
+
+        session.LoadCutoffs(saved, enabledGrades);
+
+        Assert.Equal(1, lastChangeFires);
+        Assert.Null(session.LastChange.Originator);
+        Assert.Equal(420, session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.A).Score);
+        Assert.Equal(220, session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.B).Score);
+        Assert.Contains(TestFixtures.GradeC, session.CurrentState.EnabledGrades);
+    }
+
+    [Fact]
+    public void LoadCutoffs_WithSubsetEnabledGrades_DisablesMissingSlots()
+    {
+        var session = TestFixtures.SessionForGrading();
+        var saved = new List<GradeCutoff>
+        {
+            new(TestFixtures.GradeA, 420),
+            new(TestFixtures.GradeB, 220),
+            new(TestFixtures.GradeC, 60),
+        };
+        var enabledGrades = new HashSet<Grade>
+        {
+            TestFixtures.GradeA, TestFixtures.GradeC,  // B disabled
+        };
+
+        session.LoadCutoffs(saved, enabledGrades);
+
+        Assert.False(session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.B).IsEnabled);
+        Assert.True(session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.A).IsEnabled);
+    }
+
+    [Fact]
+    public void ReseedFromDefaults_RestoresInitialCutoffsViaInitialCutoffCalculator()
+    {
+        var session = TestFixtures.SessionForGrading();
+        var slotA = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.A);
+        var slotB = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.B);
+
+        // Move A and B around so the state is materially different from initial.
+        session.MoveCutoff(slotA.Grade, 400, new object());
+        session.MoveCutoff(slotB.Grade, 200, new object());
+
+        session.ReseedFromDefaults();
+
+        // Initial cutoffs from the fixture: A=450, B=250 (C=50 catch-all).
+        Assert.Equal(450, slotA.Score);
+        Assert.Equal(250, slotB.Score);
+    }
+
+    [Fact]
+    public void AssignedGradeFor_ReturnsGradeAccordingToCurrentCutoffs()
+    {
+        // Fixture initial cutoffs: A=450, B=250, C=50 (catch-all).
+        // Student id 50 has AggregateGrade = 540 → above A → assigned A.
+        // Student id 1 has AggregateGrade = 50 → at the catch-all boundary → assigned C.
+        var session = TestFixtures.SessionForGrading();
+
+        var topStudent = session.AssignedGradeFor(studentId: 50);
+        var bottomStudent = session.AssignedGradeFor(studentId: 1);
+
+        Assert.Equal(LetterGrade.A, topStudent.LetterGrade);
+        Assert.Equal(LetterGrade.C, bottomStudent.LetterGrade);
+    }
+
+    [Fact]
+    public void Slots_AreFixedLengthAcrossEnableDisableCycles()
+    {
+        var session = TestFixtures.SessionForGrading();
+        var initialCount = session.Slots.Count;
+        var slotB = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.B);
+
+        session.DisableGrade(slotB.Grade);
+        Assert.Equal(initialCount, session.Slots.Count);
+
+        session.EnableGrade(slotB.Grade);
+        Assert.Equal(initialCount, session.Slots.Count);
+    }
+
+    [Fact]
+    public void CurrentState_FiresPropertyChangedAlongsideLastChange()
+    {
+        var session = TestFixtures.SessionForGrading();
+        var lastChangeFires = 0;
+        var currentStateFires = 0;
+        session.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(GradingSession.LastChange)) lastChangeFires++;
+            if (e.PropertyName == nameof(GradingSession.CurrentState)) currentStateFires++;
+        };
+
+        var slotB = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.B);
+        session.MoveCutoff(slotB.Grade, slotB.Score + 5, new object());
+
+        Assert.Equal(1, lastChangeFires);
+        Assert.Equal(1, currentStateFires);
+    }
+}

--- a/Dotsesses/Models/CutoffMoveResult.cs
+++ b/Dotsesses/Models/CutoffMoveResult.cs
@@ -1,0 +1,20 @@
+namespace Dotsesses.Models;
+
+/// <summary>
+/// Outcome of GradingSession.CanMoveCutoff / MoveCutoff. Success
+/// carries no failure; rejected moves leave session state untouched
+/// and report which constraint was violated.
+/// </summary>
+public sealed record CutoffMoveResult(bool Success, CutoffMoveFailure? Failure)
+{
+    public static CutoffMoveResult Ok() => new(true, null);
+    public static CutoffMoveResult Fail(CutoffMoveFailure failure) => new(false, failure);
+}
+
+public enum CutoffMoveFailure
+{
+    OutOfRange,
+    WouldOverlap,
+    OrderingViolation,
+    GradeNotEnabled,
+}

--- a/Dotsesses/Models/GradingState.cs
+++ b/Dotsesses/Models/GradingState.cs
@@ -1,0 +1,13 @@
+namespace Dotsesses.Models;
+
+/// <summary>
+/// Immutable snapshot of a Class's grading at one moment — current
+/// GradeCutoffs, derived per-Grade CutoffCounts, and the set of
+/// EnabledGrades. Every accepted change to a GradingSession produces
+/// a new GradingState, carried as the State member of the
+/// corresponding GradingStateChange. See ADR-0008.
+/// </summary>
+public sealed record GradingState(
+    IReadOnlyList<GradeCutoff> Cutoffs,
+    IReadOnlyList<CutoffCount> Counts,
+    IReadOnlySet<Grade> EnabledGrades);

--- a/Dotsesses/Models/GradingStateChange.cs
+++ b/Dotsesses/Models/GradingStateChange.cs
@@ -1,0 +1,13 @@
+namespace Dotsesses.Models;
+
+/// <summary>
+/// The payload of a GradingSession's LastChange notification: the
+/// new immutable GradingState plus the object that initiated the
+/// change. Read-only consumers ignore Originator; read-and-write
+/// consumers (drag handlers) call IsFrom(this) to bail on
+/// self-initiated changes. See ADR-0010.
+/// </summary>
+public sealed record GradingStateChange(object? Originator, GradingState State)
+{
+    public bool IsFrom(object? obj) => obj is not null && ReferenceEquals(obj, Originator);
+}

--- a/Dotsesses/UI/CutoffSlot.cs
+++ b/Dotsesses/UI/CutoffSlot.cs
@@ -1,0 +1,39 @@
+namespace Dotsesses.UI;
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using Dotsesses.Models;
+
+/// <summary>
+/// UI-binding adapter for one GradeCutoff inside a GradingSession.
+/// Slots have stable per-Grade identity for the lifetime of the
+/// session (per ADR-0008). Score and IsEnabled setters are internal
+/// — only the owning GradingSession mutates them; consumers bind
+/// read-only.
+/// </summary>
+public sealed class CutoffSlot : ObservableObject
+{
+    private int _score;
+    private bool _isEnabled;
+
+    public Grade Grade { get; }
+
+    public int Score
+    {
+        get => _score;
+        internal set => SetProperty(ref _score, value);
+    }
+
+    public bool IsEnabled
+    {
+        get => _isEnabled;
+        internal set => SetProperty(ref _isEnabled, value);
+    }
+
+    internal CutoffSlot(Grade grade, int score, bool isEnabled)
+    {
+        ArgumentNullException.ThrowIfNull(grade);
+        Grade = grade;
+        _score = score;
+        _isEnabled = isEnabled;
+    }
+}

--- a/Dotsesses/UI/GradingSession.cs
+++ b/Dotsesses/UI/GradingSession.cs
@@ -1,0 +1,351 @@
+namespace Dotsesses.UI;
+
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Dotsesses.Calculators;
+using Dotsesses.Models;
+
+/// <summary>
+/// Owns one Class's live grading state and broadcasts every accepted
+/// change as a single GradingStateChange notification. See ADR-0008
+/// (structural immutability) and ADR-0010 (state sync via observable
+/// property with originator tagging).
+/// </summary>
+public sealed class GradingSession : ObservableObject
+{
+    private readonly ClassAssessment _classAssessment;
+    private readonly CursorPlacementCalculator _cursorPlacement;
+    private readonly CursorValidation _cursorValidation;
+    private readonly CutoffCountCalculator _cutoffCountCalculator;
+    private readonly InitialCutoffCalculator _initialCutoffCalculator;
+    private readonly Grade _structuralCatchAll;
+    private readonly ObservableCollection<CutoffSlot> _slots;
+    private readonly int _minScore;
+    private readonly int _maxScore;
+    private int _catchAllScore;
+    private GradingStateChange _lastChange = null!;
+
+    // Margin around the AggregateGrade envelope so cursors can sit
+    // just outside the data extremes (matches DefaultCursorSpacing
+    // in InitialCutoffCalculator). See Q2 in
+    // .conversations/2026-05-07_issue-7-grading-session-design.md.
+    private const int ScoreBoundsMargin = 12;
+
+    public ReadOnlyObservableCollection<CutoffSlot> Slots { get; }
+
+    public GradingStateChange LastChange
+    {
+        get => _lastChange;
+        private set
+        {
+            if (SetProperty(ref _lastChange, value))
+            {
+                OnPropertyChanged(nameof(CurrentState));
+            }
+        }
+    }
+
+    public GradingState CurrentState => LastChange.State;
+
+    public GradingSession(
+        ClassAssessment classAssessment,
+        CursorPlacementCalculator cursorPlacement,
+        CursorValidation cursorValidation,
+        CutoffCountCalculator cutoffCountCalculator,
+        InitialCutoffCalculator initialCutoffCalculator)
+    {
+        ArgumentNullException.ThrowIfNull(classAssessment);
+        ArgumentNullException.ThrowIfNull(cursorPlacement);
+        ArgumentNullException.ThrowIfNull(cursorValidation);
+        ArgumentNullException.ThrowIfNull(cutoffCountCalculator);
+        ArgumentNullException.ThrowIfNull(initialCutoffCalculator);
+
+        _classAssessment = classAssessment;
+        _cursorPlacement = cursorPlacement;
+        _cursorValidation = cursorValidation;
+        _cutoffCountCalculator = cutoffCountCalculator;
+        _initialCutoffCalculator = initialCutoffCalculator;
+
+        if (classAssessment.Assessments.Count == 0)
+        {
+            throw new InvalidOperationException(
+                "ClassAssessment has no StudentAssessments; GradingSession " +
+                "cannot derive score bounds from an empty class.");
+        }
+
+        _minScore = classAssessment.Assessments.Min(a => a.AggregateGrade) - ScoreBoundsMargin;
+        _maxScore = classAssessment.Assessments.Max(a => a.AggregateGrade) + ScoreBoundsMargin;
+
+        var midpointCurve = classAssessment.DefaultCurve
+            .Where(r => r.LowerBound > 0 || r.UpperBound > 0)
+            .Select(r => new CutoffCount(r.Grade, r.Midpoint))
+            .OrderBy(c => c.Grade.Order)
+            .ToList();
+
+        if (midpointCurve.Count == 0)
+        {
+            throw new InvalidOperationException(
+                "DefaultCurve has no targeted grades (all ranges are zero); " +
+                "GradingSession requires at least one targeted grade.");
+        }
+
+        var initialCutoffs = _initialCutoffCalculator
+            .Calculate(classAssessment.Assessments, midpointCurve)
+            .OrderBy(c => c.Grade.Order)
+            .ToList();
+
+        // The lowest-Order grade in the initial cutoffs is the structural
+        // catch-all (Q1=C): it has no Slot and is always implicitly
+        // enabled. Per ADR-0008, this designation is fixed at construction.
+        _structuralCatchAll = initialCutoffs[^1].Grade;
+        _catchAllScore = initialCutoffs[^1].Score;
+
+        _slots = new ObservableCollection<CutoffSlot>(
+            initialCutoffs
+                .Where(c => !c.Grade.Equals(_structuralCatchAll))
+                .Select(c => new CutoffSlot(c.Grade, c.Score, isEnabled: true)));
+
+        Slots = new ReadOnlyObservableCollection<CutoffSlot>(_slots);
+
+        var enabledGrades = initialCutoffs
+            .Select(c => c.Grade)
+            .ToHashSet();
+
+        var counts = _cutoffCountCalculator
+            .Calculate(classAssessment.Assessments, initialCutoffs)
+            .OrderBy(c => c.Grade.Order)
+            .ToList();
+
+        var initialState = new GradingState(
+            Cutoffs: initialCutoffs,
+            Counts: counts,
+            EnabledGrades: enabledGrades);
+
+        _lastChange = new GradingStateChange(Originator: null, State: initialState);
+    }
+
+    public CutoffMoveResult CanMoveCutoff(Grade grade, int newScore)
+    {
+        var slot = RequireDraggableSlot(grade);
+        return ValidateMove(slot, newScore);
+    }
+
+    public CutoffMoveResult MoveCutoff(Grade grade, int newScore, object originator)
+    {
+        ArgumentNullException.ThrowIfNull(originator);
+        var slot = RequireDraggableSlot(grade);
+
+        var validation = ValidateMove(slot, newScore);
+        if (!validation.Success) return validation;
+
+        slot.Score = newScore;
+        EmitNewState(originator);
+        return CutoffMoveResult.Ok();
+    }
+
+    public void EnableGrade(Grade grade, object? originator = null)
+    {
+        var slot = RequireDraggableSlot(grade);
+        if (slot.IsEnabled) return;
+
+        var existingCutoffs = BuildCurrentCutoffs();
+        var placed = _cursorPlacement
+            .PlaceNewCursor(slot.Grade, existingCutoffs, _minScore, _maxScore);
+
+        // PlaceNewCursor may reseed all enabled grades. Apply the result back
+        // uniformly across slots and the catch-all so the caller observes a
+        // single coherent state when LastChange fires below.
+        foreach (var c in placed)
+        {
+            if (c.Grade.Equals(_structuralCatchAll))
+            {
+                _catchAllScore = c.Score;
+            }
+            else
+            {
+                var matching = _slots.FirstOrDefault(s => s.Grade.Equals(c.Grade));
+                if (matching is not null)
+                {
+                    matching.Score = c.Score;
+                }
+            }
+        }
+
+        slot.IsEnabled = true;
+        EmitNewState(originator);
+    }
+
+    public void DisableGrade(Grade grade, object? originator = null)
+    {
+        var slot = RequireDraggableSlot(grade);
+        if (!slot.IsEnabled) return;
+
+        slot.IsEnabled = false;
+        EmitNewState(originator);
+    }
+
+    public void ReseedFromDefaults(object? originator = null)
+    {
+        var midpointCurve = _classAssessment.DefaultCurve
+            .Where(r => r.LowerBound > 0 || r.UpperBound > 0)
+            .Select(r => new CutoffCount(r.Grade, r.Midpoint))
+            .OrderBy(c => c.Grade.Order)
+            .ToList();
+
+        var seeded = _initialCutoffCalculator
+            .Calculate(_classAssessment.Assessments, midpointCurve)
+            .ToList();
+
+        ApplyCutoffsToInternalState(seeded, enabledGrades: null);
+        EmitNewState(originator);
+    }
+
+    public void LoadCutoffs(
+        IReadOnlyList<GradeCutoff> cutoffs,
+        IReadOnlySet<Grade> enabledGrades,
+        object? originator = null)
+    {
+        ArgumentNullException.ThrowIfNull(cutoffs);
+        ArgumentNullException.ThrowIfNull(enabledGrades);
+
+        ApplyCutoffsToInternalState(cutoffs, enabledGrades);
+        EmitNewState(originator);
+    }
+
+    public Grade AssignedGradeFor(int studentId)
+    {
+        var student = _classAssessment.Assessments.FirstOrDefault(a => a.Id == studentId)
+            ?? throw new ArgumentException(
+                $"No StudentAssessment with id {studentId} in this class.",
+                nameof(studentId));
+
+        var assigner = new GradeAssigner(CurrentState.Cutoffs);
+        return assigner.AssignGrade(student.AggregateGrade);
+    }
+
+    private void ApplyCutoffsToInternalState(
+        IReadOnlyCollection<GradeCutoff> cutoffs,
+        IReadOnlySet<Grade>? enabledGrades)
+    {
+        // If enabledGrades is null (e.g. ReseedFromDefaults), every slot
+        // present in the supplied cutoffs is treated as enabled and slots
+        // not in the supplied cutoffs are disabled.
+        var supplied = cutoffs.ToDictionary(c => c.Grade);
+
+        if (supplied.TryGetValue(_structuralCatchAll, out var catchAllCutoff))
+        {
+            _catchAllScore = catchAllCutoff.Score;
+        }
+
+        foreach (var slot in _slots)
+        {
+            var hasCutoff = supplied.TryGetValue(slot.Grade, out var c);
+            if (hasCutoff)
+            {
+                slot.Score = c!.Score;
+            }
+
+            slot.IsEnabled = enabledGrades is null
+                ? hasCutoff
+                : enabledGrades.Contains(slot.Grade);
+        }
+    }
+
+    private CutoffSlot RequireDraggableSlot(Grade grade)
+    {
+        ArgumentNullException.ThrowIfNull(grade);
+
+        if (grade.Equals(_structuralCatchAll))
+        {
+            throw new ArgumentException(
+                $"Grade {grade.DisplayName} is the structural catch-all and has no draggable cutoff.",
+                nameof(grade));
+        }
+
+        return _slots.FirstOrDefault(s => s.Grade.Equals(grade))
+            ?? throw new ArgumentException(
+                $"Grade {grade.DisplayName} is not part of this session's slot collection.",
+                nameof(grade));
+    }
+
+    private CutoffMoveResult ValidateMove(CutoffSlot slot, int newScore)
+    {
+        if (!slot.IsEnabled)
+            return CutoffMoveResult.Fail(CutoffMoveFailure.GradeNotEnabled);
+
+        if (newScore < _minScore || newScore > _maxScore)
+            return CutoffMoveResult.Fail(CutoffMoveFailure.OutOfRange);
+
+        var (better, worse) = FindAdjacentEnabledCutoffs(slot.Grade);
+
+        if (worse is not null)
+        {
+            if (newScore < worse.Score)
+                return CutoffMoveResult.Fail(CutoffMoveFailure.OrderingViolation);
+            if (newScore == worse.Score)
+                return CutoffMoveResult.Fail(CutoffMoveFailure.WouldOverlap);
+        }
+
+        if (better is not null)
+        {
+            if (newScore > better.Score)
+                return CutoffMoveResult.Fail(CutoffMoveFailure.OrderingViolation);
+            if (newScore == better.Score)
+                return CutoffMoveResult.Fail(CutoffMoveFailure.WouldOverlap);
+        }
+
+        return CutoffMoveResult.Ok();
+    }
+
+    private (GradeCutoff? Better, GradeCutoff? Worse) FindAdjacentEnabledCutoffs(Grade grade)
+    {
+        // "Better" = lower Order than `grade` (higher score expected);
+        // "Worse" = higher Order (lower score expected; may be the catch-all).
+        var enabledCutoffs = CurrentState.Cutoffs
+            .Where(c => CurrentState.EnabledGrades.Contains(c.Grade))
+            .ToList();
+
+        var better = enabledCutoffs
+            .Where(c => c.Grade.Order < grade.Order)
+            .OrderByDescending(c => c.Grade.Order)
+            .FirstOrDefault();
+
+        var worse = enabledCutoffs
+            .Where(c => c.Grade.Order > grade.Order)
+            .OrderBy(c => c.Grade.Order)
+            .FirstOrDefault();
+
+        return (better, worse);
+    }
+
+    private List<GradeCutoff> BuildCurrentCutoffs()
+    {
+        // Slot scores are authoritative for non-catch-all enabled grades.
+        // The catch-all's score lives on _catchAllScore; GradeAssigner uses
+        // it as a fallback only (it is never draggable).
+        return _slots
+            .Where(s => s.IsEnabled)
+            .Select(s => new GradeCutoff(s.Grade, s.Score))
+            .Append(new GradeCutoff(_structuralCatchAll, _catchAllScore))
+            .OrderBy(c => c.Grade.Order)
+            .ToList();
+    }
+
+    private void EmitNewState(object? originator)
+    {
+        var newCutoffs = BuildCurrentCutoffs();
+        var newCounts = _cutoffCountCalculator
+            .Calculate(_classAssessment.Assessments, newCutoffs)
+            .OrderBy(c => c.Grade.Order)
+            .ToList();
+
+        var enabled = _slots
+            .Where(s => s.IsEnabled)
+            .Select(s => s.Grade)
+            .Append(_structuralCatchAll)
+            .ToHashSet();
+
+        var newState = new GradingState(newCutoffs, newCounts, enabled);
+        LastChange = new GradingStateChange(originator, newState);
+    }
+}

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -69,3 +69,32 @@ that work.
 
 **Touches:** `MainWindowViewModel.cs` (the two `Initialize*` methods
 and their callers).
+
+---
+
+### TD004 — `CursorPlacementCalculator.ResetToEvenSpacing` produces inverted Score-vs-Order ordering
+
+**Why it's debt:** The private fallback used when `PlaceNewCursor`
+detects an overlap sorts grades by `Order` ascending and then assigns
+`minScore + spacing * (i + 1)` left-to-right. Because A has the
+lowest `Order` (0) and F the highest (10), this gives A the *smallest*
+score and F the *largest* — the opposite of the intended grade →
+score relationship. `GradeAssigner.ValidateCutoffOrdering` would
+throw on the result, so any caller that triggers the reseed path is
+broken. The existing
+`CursorPlacementCalculatorTests.PlaceNewCursor_CausesOverlap_ResetsAllToEvenSpacing`
+only checks that spacing is roughly even and so does not catch this.
+
+The public `ResetToEvenSpacingMonotonic` overload (used by
+`SeedCursorsFromDefaults` per M002/S05) gets the orientation right —
+it inverts the fraction so best grade lands at `maxScore`. The
+private fallback should adopt the same orientation.
+
+**Trigger:** Slice #3 of issue #6 (cursor drag migration). The
+GradingSession's `EnableGrade` exercises this path; the related
+"EnableGrade triggers reseed" test in `GradingSessionTests` is
+deferred until this is fixed.
+
+**Touches:** `Calculators/CursorPlacementCalculator.cs` (the private
+`ResetToEvenSpacing`), and the existing test should be tightened to
+assert orientation, not just even spacing.

--- a/docs/adr/0011-slots-collection-excludes-structural-catchall.md
+++ b/docs/adr/0011-slots-collection-excludes-structural-catchall.md
@@ -1,0 +1,61 @@
+# `GradingSession.Slots` excludes the structural catch-all Grade
+
+The `Slots` collection on a `GradingSession` exposes a `CutoffSlot`
+for every Grade in the session's structural set **except** the
+structural catch-all — i.e. the lowest-Order Grade in the initial
+cutoffs at construction time. The catch-all has no slot, is always
+present in `GradingState.EnabledGrades`, and cannot be moved,
+disabled, or re-enabled. Its score lives on a private field inside
+the session and is only mutated by `LoadCutoffs` /
+`ReseedFromDefaults` / a reseed inside `EnableGrade`.
+
+## Why
+
+There is no draggable cursor for the catch-all in the UI today, and
+exposing a slot for it would invite consumers to bind a cursor visual
+to something that has no defined "minimum score" semantics
+(GradeAssigner uses the catch-all as a fallback only — its score
+isn't a threshold). Returning `Failure(NotDraggable)` from
+`MoveCutoff` for the catch-all would also force callers to handle a
+runtime-only failure mode for what is really a programmer error
+(asking the API to do something it doesn't support).
+
+By excluding the catch-all from `Slots` entirely:
+
+- UI bindings to `Slots` automatically skip the catch-all without a
+  filter.
+- Calling `MoveCutoff(catchAll, …)` is a programmer error and throws
+  `ArgumentException`, surfacing the misuse at the call site rather
+  than threading a special failure variant through the type.
+- `EnableGrade` / `DisableGrade` are scoped to slot-bearing grades
+  only — the catch-all is always implicitly enabled.
+- `CutoffMoveFailure` stays at the four PRD-listed variants; no new
+  variant for "this isn't a draggable slot."
+
+## Considered alternatives
+
+- **A — slot for the catch-all, new `NotDraggable` failure variant.**
+  Adds an enum variant that every caller must handle just to receive
+  "you should not have called this" — programmer error masquerading
+  as runtime failure.
+- **B — slot for the catch-all, `MoveCutoff` returns
+  `Failure(GradeNotEnabled)`.** Overloads `GradeNotEnabled` to mean
+  two different things (the user disabled it vs. the catch-all is
+  not draggable by design), making the failure mode less informative.
+
+Both options also leak the catch-all into UI binding scenarios that
+have no place for it.
+
+## Consequences
+
+- `Slots.Count == initial cutoffs count − 1` for the lifetime of the
+  session.
+- `MoveCutoff(catchAll, …)`, `EnableGrade(catchAll, …)`,
+  `DisableGrade(catchAll, …)` all throw `ArgumentException`.
+- The catch-all's score is mutated only via batch operations
+  (`LoadCutoffs`, `ReseedFromDefaults`) or as a side-effect of a
+  reseed inside `EnableGrade`. There is no per-cursor-move path that
+  changes it.
+- This decision is independent of ADR-0008's structural-immutability
+  rule but reinforces it: the slot collection is fixed at
+  construction in both length *and* membership.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## Summary

Slice 1 of the issue #6 refactor. Introduces `GradingSession` — the observable owner of one Class's live grading state — alongside the existing code with no production consumers wired in. The full PRD API surface is implemented and exercised through a pure-unit test class.

- New types: `GradingState`, `GradingStateChange`, `CutoffMoveResult` / `CutoffMoveFailure`, `CutoffSlot`, `GradingSession`
- 22 new `GradingSessionTests` covering every API contract
- `MainWindowViewModel`, `ViolinPlotViewModel`, `StateService` untouched — wiring lands in slices #2–#5
- Per Q1=C in the design questionnaire and the new ADR-0011, the structural catch-all Grade has no Slot

## Test plan

- [x] `dotnet build` — passes
- [x] `dotnet test` — 166/166 passing (22 new + 144 pre-existing, no regressions)
- [x] All acceptance criteria from #7 satisfied (one sub-test deferred — see below)

## Deferred

"EnableGrade triggering full reseed emits exactly one `LastChange`" — depends on **TD004** (orientation bug in `CursorPlacementCalculator.ResetToEvenSpacing`). The post-reseed cutoffs are score-ascending where they should be score-descending, which `GradeAssigner.ValidateCutoffOrdering` rejects. Documented in `TECH_DEBT.md`; will be fixed before slice #3 (cursor-drag migration) lands.

## Docs

- `CONTEXT.md` — added catch-all-no-slot invariant
- `TECH_DEBT.md` — TD004 (`ResetToEvenSpacing` orientation bug)
- `docs/adr/0011-slots-collection-excludes-structural-catchall.md` — records the Q1=C decision

Closes #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)