### PR TITLE
feat(GradingSession): route cursor drag through session (slice 3 of #6)

### DIFF
--- a/Dotsesses.Tests/UI/GradingSessionTests.cs
+++ b/Dotsesses.Tests/UI/GradingSessionTests.cs
@@ -68,15 +68,13 @@ public class GradingSessionTests
     [Fact]
     public void MoveCutoff_AboveMaxAggregatePlusMargin_FailsWithOutOfRange()
     {
-        // Arrange — fixture: AggregateGrades 50..540 → max + 12 = 552
+        // Fixture: AggregateGrades 50..540 → max + 5 = 545.
         var session = TestFixtures.SessionForGrading();
         var slotA = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.A);
         var stateBefore = session.LastChange.State;
 
-        // Act — move A to 600 (well outside the upper bound)
         var result = session.MoveCutoff(slotA.Grade, 600, new object());
 
-        // Assert
         Assert.False(result.Success);
         Assert.Equal(CutoffMoveFailure.OutOfRange, result.Failure);
         Assert.Same(stateBefore, session.LastChange.State);
@@ -85,18 +83,31 @@ public class GradingSessionTests
     [Fact]
     public void MoveCutoff_BelowMinAggregateMinusMargin_FailsWithOutOfRange()
     {
-        // Arrange — fixture: AggregateGrades 50..540 → min − 12 = 38
+        // Fixture: AggregateGrades 50..540 → min − 1 = 49.
         var session = TestFixtures.SessionForGrading();
         var slotB = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.B);
         var stateBefore = session.LastChange.State;
 
-        // Act — move B to 0 (below the lower bound)
         var result = session.MoveCutoff(slotB.Grade, 0, new object());
 
-        // Assert
         Assert.False(result.Success);
         Assert.Equal(CutoffMoveFailure.OutOfRange, result.Failure);
         Assert.Same(stateBefore, session.LastChange.State);
+    }
+
+    [Fact]
+    public void MoveCutoff_AtUpperBoundExactly_IsAccepted_OnePastFails()
+    {
+        // Fixture: max=540 → max+5=545 (inclusive). 546 is OutOfRange.
+        var session = TestFixtures.SessionForGrading();
+        var slotA = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.A);
+
+        var atBound = session.MoveCutoff(slotA.Grade, 545, new object());
+        Assert.True(atBound.Success);
+
+        var pastBound = session.MoveCutoff(slotA.Grade, 546, new object());
+        Assert.False(pastBound.Success);
+        Assert.Equal(CutoffMoveFailure.OutOfRange, pastBound.Failure);
     }
 
     [Fact]

--- a/Dotsesses.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/Dotsesses.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -326,6 +326,25 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
+    public void GradingSession_MoveCutoff_MirrorsIntoLegacyCursorsCollection()
+    {
+        // Slice 3: drag goes through GradingSession.MoveCutoff. The legacy
+        // Cursors collection mirror-syncs from session.LastChange so existing
+        // OxyPlot rendering and Compliance recalc paths keep working until
+        // the cleanup slice (issue #14) deletes _cursors entirely.
+        var vm = CreateViewModel();
+        var slotA = vm.GradingSession.Slots.First(s => s.Grade.LetterGrade == LetterGrade.A);
+        var initial = slotA.Score;
+        var newScore = initial - 5;
+
+        vm.GradingSession.MoveCutoff(slotA.Grade, newScore, originator: this);
+
+        var legacyA = vm.Cursors.First(c => c.Grade.LetterGrade == LetterGrade.A);
+        Assert.Equal(newScore, slotA.Score);
+        Assert.Equal(newScore, legacyA.Score);
+    }
+
+    [Fact]
     public async Task LoadStateAsync_V2File_HydratesGradingSession()
     {
         // VM-driven round-trip: save a session with a non-default cutoff,

--- a/Dotsesses/UI/GradingSession.cs
+++ b/Dotsesses/UI/GradingSession.cs
@@ -25,11 +25,13 @@ public sealed class GradingSession : ObservableObject
     private int _catchAllScore;
     private GradingStateChange _lastChange = null!;
 
-    // Margin around the AggregateGrade envelope so cursors can sit
-    // just outside the data extremes (matches DefaultCursorSpacing
-    // in InitialCutoffCalculator). See Q2 in
-    // .conversations/2026-05-07_issue-7-grading-session-design.md.
-    private const int ScoreBoundsMargin = 12;
+    // Asymmetric margin around the AggregateGrade envelope: cursors
+    // can sit just below the lowest student score (so the catch-all
+    // band stays visible) and well above the highest (so the A
+    // boundary can be pushed past the top scorer to make A
+    // unattainable). Issue #9 / Q3: maintainer-chosen [-1, +5].
+    private const int ScoreBoundsMarginBelow = 1;
+    private const int ScoreBoundsMarginAbove = 5;
 
     public ReadOnlyObservableCollection<CutoffSlot> Slots { get; }
 
@@ -73,8 +75,8 @@ public sealed class GradingSession : ObservableObject
                 "cannot derive score bounds from an empty class.");
         }
 
-        _minScore = classAssessment.Assessments.Min(a => a.AggregateGrade) - ScoreBoundsMargin;
-        _maxScore = classAssessment.Assessments.Max(a => a.AggregateGrade) + ScoreBoundsMargin;
+        _minScore = classAssessment.Assessments.Min(a => a.AggregateGrade) - ScoreBoundsMarginBelow;
+        _maxScore = classAssessment.Assessments.Max(a => a.AggregateGrade) + ScoreBoundsMarginAbove;
 
         var midpointCurve = classAssessment.DefaultCurve
             .Where(r => r.LowerBound > 0 || r.UpperBound > 0)

--- a/Dotsesses/UI/MainWindowViewModel.cs
+++ b/Dotsesses/UI/MainWindowViewModel.cs
@@ -128,6 +128,50 @@ public partial class MainWindowViewModel : ViewModelBase
     /// </summary>
     public StateService StateService => _stateService;
 
+    /// <summary>
+    /// Mirrors the GradingSession's slot state into the legacy
+    /// <see cref="Cursors"/> collection so existing OxyPlot rendering
+    /// and Compliance recalc paths keep working while drag goes
+    /// through the session. Called when GradingSession swaps in
+    /// (file load) and on every session.LastChange notification.
+    /// Slice 3 of issue #6 — minimal scope. Future cleanup slice will
+    /// remove _cursors entirely (see issue #14).
+    /// </summary>
+    private void SyncCursorsFromSession()
+    {
+        if (GradingSession is null) return;
+        foreach (var slot in GradingSession.Slots)
+        {
+            var cursor = Cursors.FirstOrDefault(c => c.Grade.Equals(slot.Grade));
+            if (cursor is null) continue;
+            if (cursor.Score != slot.Score) cursor.Score = slot.Score;
+            if (cursor.IsEnabled != slot.IsEnabled) cursor.IsEnabled = slot.IsEnabled;
+        }
+    }
+
+    partial void OnGradingSessionChanged(GradingSession? oldValue, GradingSession newValue)
+    {
+        if (oldValue is not null)
+        {
+            oldValue.PropertyChanged -= OnGradingSessionPropertyChanged;
+        }
+        if (newValue is not null)
+        {
+            newValue.PropertyChanged += OnGradingSessionPropertyChanged;
+        }
+
+        if (ViolinPlotViewModel is not null)
+        {
+            ViolinPlotViewModel.GradingSession = newValue;
+        }
+    }
+
+    private void OnGradingSessionPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(GradingSession.LastChange)) return;
+        SyncCursorsFromSession();
+    }
+
     public MainWindowViewModel()
     {
         
@@ -1956,29 +2000,25 @@ public partial class MainWindowViewModel : ViewModelBase
 
         var newScore = (int)Math.Round(pos.X);
 
-        // Allow cursor movement beyond actual student scores
-        var minBound = ClassAssessment.Assessments.Min(a => a.AggregateGrade) - 20;
-        var maxBound = ClassAssessment.Assessments.Max(a => a.AggregateGrade) + 20;
-
-        // Validate cursor movement (include ALL enabled cursors for proper ordering constraints)
+        // Pre-clamp to legacy bounds so the visual continues to track the
+        // mouse smoothly past the data envelope. Session.MoveCutoff applies
+        // its own canonical bounds (see ScoreBoundsMargin{Below,Above} in
+        // GradingSession); rejected moves leave the cursor at its last
+        // valid position, which gives users implicit boundary feedback.
+        var legacyMinBound = ClassAssessment.Assessments.Min(a => a.AggregateGrade) - 20;
+        var legacyMaxBound = ClassAssessment.Assessments.Max(a => a.AggregateGrade) + 20;
         var allCutoffs = Cursors
             .Where(c => c.IsEnabled)
             .Select(c => new GradeCutoff(c.Grade, c == _draggingCursor ? newScore : c.Score))
             .ToList();
+        var clampedScore = _cursorValidation.ValidateMovement(
+            _draggingCursor.Grade, newScore, allCutoffs, (int)legacyMinBound, (int)legacyMaxBound);
 
-        var validatedScore = _cursorValidation.ValidateMovement(_draggingCursor.Grade, newScore, allCutoffs, (int)minBound, (int)maxBound);
-
-        _isUpdatingCursorsFromSubscription = true;
-        try
-        {
-            _draggingCursor.Score = validatedScore;
-            UpdateCursors();
-            RecalculateGradeCounts(); // Update counts during drag
-        }
-        finally
-        {
-            _isUpdatingCursorsFromSubscription = false;
-        }
+        // Slice 3: route the commit through GradingSession. The session
+        // emits LastChange on success → SyncCursorsFromSession mirrors
+        // back into _cursors → existing cursor PropertyChanged handlers
+        // update OxyPlot annotations and Compliance counts.
+        GradingSession?.MoveCutoff(_draggingCursor.Grade, clampedScore, this);
         e.Handled = true;
     }
 

--- a/Dotsesses/UI/ViolinPlotControl.axaml.cs
+++ b/Dotsesses/UI/ViolinPlotControl.axaml.cs
@@ -930,17 +930,21 @@ public partial class ViolinPlotControl : UserControl
         // Convert to raw score (can be beyond MinScore/MaxScore)
         var newScore = vm.NormalizedToScore(normalized);
 
-        // Build cutoffs with proposed position
+        // Build cutoffs with proposed position so the legacy spacing
+        // clamp can produce a visually-smooth pre-commit score.
         var allCutoffs = vm.Cursors
             .Where(c => c.IsEnabled)
             .Select(c => new GradeCutoff(c.Grade, c == _draggingBarbellCursor ? newScore : c.Score))
             .ToList();
-
-        // Validate movement - use very wide bounds to allow full range
-        var validated = _cursorValidation.ValidateMovement(
+        var clamped = _cursorValidation.ValidateMovement(
             _draggingBarbellCursor.Grade, newScore, allCutoffs, int.MinValue, int.MaxValue);
 
-        _draggingBarbellCursor.Score = validated;
+        // Slice 3: route the commit through GradingSession. The session
+        // applies canonical out-of-range bounds (issue #9 / Q3: -1, +5);
+        // rejected moves leave the cursor at its last valid position,
+        // and the mirror sync in MainWindowViewModel updates vm.Cursors
+        // on success.
+        vm.GradingSession?.MoveCutoff(_draggingBarbellCursor.Grade, clamped, this);
         e.Handled = true;
     }
 
@@ -1194,17 +1198,20 @@ public partial class ViolinPlotControl : UserControl
         // Convert to raw score (can be beyond MinScore/MaxScore)
         var newScore = vm.NormalizedToScore(normalized);
 
-        // Build cutoffs with proposed position
+        // Pre-clamp via legacy spacing rules so the visual lags the
+        // mouse smoothly past adjacent neighbors.
         var allCutoffs = vm.Cursors
             .Where(c => c.IsEnabled)
             .Select(c => new GradeCutoff(c.Grade, c == _draggingCursor ? newScore : c.Score))
             .ToList();
-
-        // Validate movement - use very wide bounds to allow full range
-        var validated = _cursorValidation.ValidateMovement(
+        var clamped = _cursorValidation.ValidateMovement(
             _draggingCursor.Grade, newScore, allCutoffs, int.MinValue, int.MaxValue);
 
-        _draggingCursor.Score = validated;
+        // Slice 3: route the commit through GradingSession (issue #6
+        // ADR-0010). Mirror sync in MainWindowViewModel reflects the
+        // change back into vm.Cursors so existing rendering keeps
+        // working until issue #14's cleanup.
+        vm.GradingSession?.MoveCutoff(_draggingCursor.Grade, clamped, this);
         e.Handled = true;
     }
 

--- a/Dotsesses/UI/ViolinPlotViewModel.cs
+++ b/Dotsesses/UI/ViolinPlotViewModel.cs
@@ -53,6 +53,16 @@ public partial class ViolinPlotViewModel : ViewModelBase
     [ObservableProperty]
     private int _maxScore;
 
+    /// <summary>
+    /// The active GradingSession, pushed in from MainWindowViewModel after
+    /// every load. The violin's drag handlers commit through this; the
+    /// legacy <see cref="Cursors"/> collection is mirror-synced from
+    /// session by MainWindowViewModel and remains the source for
+    /// rendering until the slice 3 cleanup follow-up (issue #14).
+    /// </summary>
+    [ObservableProperty]
+    private GradingSession? _gradingSession;
+
 
     public ViolinPlotViewModel(ViolinPlotService violinService, IMessenger messenger, HoverDelayService hoverDelayService)
     {

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -138,24 +138,11 @@ shape).
 
 ---
 
-### TD007 — Cursor drag accepts scores below the AggregateScore envelope
+### TD007 — Cursor drag accepts scores below the AggregateScore envelope *(closed)*
 
-**Why it's debt:** Surfaced during manual smoke-testing of slice 2:
-in the live UI, dragging a cursor below the visible plot range
-lets the score go past −1 (and presumably arbitrarily negative).
-The legacy drag path in `MainWindow.axaml.cs` /
-`ViolinPlotControl.axaml.cs` calls `CursorValidation.ValidateMovement`
-with `minBound` derived from screen geometry, which is not pinned
-to the dataset's `AggregateScore` floor.
-
-`GradingSession.MoveCutoff` already enforces `[min−12, max+12]`
-relative to the data envelope (Q2=B in the slice 1 questionnaire),
-so this is fixed *as a side-effect* once slice #3 of issue #6
-migrates drag through the session.
-
-**Trigger:** Slice #3 of issue #6. Verify the manual smoke test
-afterwards — and if for some reason that slice is delayed, open a
-hot-fix issue against the legacy drag path.
-
-**Touches:** none for now — the fix lands with the slice #3
-migration.
+**Resolved by issue #9 / slice 3 of #6 (2026-05-07).** Both drag
+handlers now commit through `GradingSession.MoveCutoff`, which
+enforces `[min−1, max+5]` (issue #9 / Q3, asymmetric per
+maintainer preference). Rejected moves are silently dropped, so
+the cursor visually parks at its last valid position when the
+mouse pushes past the boundary.


### PR DESCRIPTION
## Summary

Slice 3 of the issue #6 refactor, **scoped down with maintainer approval** to the drag-commit step only. Both the dotplot and violin plot drag handlers now commit through `GradingSession.MoveCutoff`. Closes TD007.

The legacy `_cursors` / `ViolinPlotViewModel.Cursors` collections and `CursorViewModel` survive as mirror-synced rendering targets — their full removal is tracked in **#14**.

## Why split?

Walking the code revealed `Cursors` is read/written in 25+ places across `MainWindowViewModel` and `ViolinPlotControl.axaml.cs`. The full slice-3 scope (per the issue body) was ~500–800 lines across 5+ files. Splitting into "drag commits only" (this PR) + "delete the legacy surface" (#14) gives reviewable changes and a clean smoke-test boundary.

## What changed

- **`GradingSession`**: `ScoreBoundsMargin` → asymmetric `ScoreBoundsMarginBelow=1` / `ScoreBoundsMarginAbove=5` (issue #9 / Q3, maintainer preference)
- **`MainWindowViewModel`**: `OnGradingSessionChanged` partial subscribes to `LastChange`, pushes the session into `ViolinPlotViewModel`. New `SyncCursorsFromSession` mirrors slot state into the legacy `Cursors` collection. Dotplot drag commits via `GradingSession.MoveCutoff(grade, score, this)`
- **`ViolinPlotViewModel`**: new `[ObservableProperty] GradingSession?`
- **`ViolinPlotControl.axaml.cs`**: both drag handlers (barbell + cursor column) commit via `vm.GradingSession?.MoveCutoff(_, _, this)`. The duplicate `_cursorValidation` stays for the pre-commit clamp until #14
- **Tests**: 1 new GradingSession edge test (at-bound accepted, one-past fails); 1 new MWVM mirror-sync test

## Test plan

- [x] `dotnet test` — 172/172 passing (2 new + bound-test comments updated; no regressions)
- [x] Asymmetric bounds verified: at upper bound (`max+5`) accepted; `+1` past fails
- [x] Drag-commit-via-session updates legacy `Cursors` collection through mirror sync
- [ ] Manual smoke test by maintainer: drag both surfaces; verify cursor parks at boundary instead of going past `max+5` / below `min-1`

## Deferred to #14

- Delete `CursorViewModel`; remove both `Cursors` collections; rebind to `session.Slots`
- Migrate `UpdateCursorsFromComplianceGrid` (Compliance toggle) and `SeedCursorsFromDefaults` to route through `session.EnableGrade` / `DisableGrade` / `ReseedFromDefaults`
- Remove `SyncCursorsFromSession`, `_isUpdatingCursorsFromSubscription`, the per-cursor `PropertyChanged` subscription
- Remove the violin's duplicate `_cursorValidation`

## Behavioural notes (deferred)

- Compliance row toggles still mutate `cursor.IsEnabled` directly; `session.CurrentState.EnabledGrades` may diverge from the rendered state until #14. Not user-visible (disabled cursors aren't draggable in the UI)
- `ApplyScoreSelections` / `SeedCursorsFromDefaults` still write `_cursors` directly

## Docs

- `TECH_DEBT.md` — TD007 closed

Closes #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)