### PR TITLE
fix: guard drag handlers from non-draggable grades (catch-all crash)

### DIFF
--- a/Dotsesses.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/Dotsesses.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -326,6 +326,33 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
+    public void Cursors_IncludesNonDraggableGrades_NotPresentInSessionSlots()
+    {
+        // Regression for the slice-3 hotfix: the legacy `Cursors` collection
+        // contains every grade in DefaultCurveGenerator.GetAllGrades() (11
+        // entries in production), including the structural catch-all (C
+        // for the production curve) and zero-range grades (CMinus, DPlus,
+        // D, F). `GradingSession.Slots` only contains the draggable
+        // grades (6 in production). A drag handler that calls
+        // `session.MoveCutoff(grade, …)` for a Cursors-only grade would
+        // see ArgumentException → uncaught → app crash. Verifying that
+        // the discrepancy exists so the drag-handler guard is justified.
+        var vm = CreateViewModel();
+        var slotGrades = vm.GradingSession.Slots.Select(s => s.Grade).ToHashSet();
+        var cursorGrades = vm.Cursors.Select(c => c.Grade).ToHashSet();
+        var nonDraggable = cursorGrades.Except(slotGrades).ToList();
+
+        Assert.NotEmpty(nonDraggable);
+        // And the session would refuse to move any of them — preserving
+        // the API contract from ADR-0011.
+        foreach (var grade in nonDraggable)
+        {
+            Assert.Throws<ArgumentException>(() =>
+                vm.GradingSession.MoveCutoff(grade, 100, originator: this));
+        }
+    }
+
+    [Fact]
     public void GradingSession_MoveCutoff_MirrorsIntoLegacyCursorsCollection()
     {
         // Slice 3: drag goes through GradingSession.MoveCutoff. The legacy

--- a/Dotsesses/UI/MainWindowViewModel.cs
+++ b/Dotsesses/UI/MainWindowViewModel.cs
@@ -2018,7 +2018,16 @@ public partial class MainWindowViewModel : ViewModelBase
         // emits LastChange on success → SyncCursorsFromSession mirrors
         // back into _cursors → existing cursor PropertyChanged handlers
         // update OxyPlot annotations and Compliance counts.
-        GradingSession?.MoveCutoff(_draggingCursor.Grade, clampedScore, this);
+        // Guard against the legacy `Cursors` collection containing
+        // non-draggable grades (the structural catch-all and any
+        // zero-range grades that aren't in `session.Slots`). The session
+        // throws ArgumentException for those (per ADR-0011); the drag
+        // handler must not propagate that to OxyPlot's event pump.
+        if (GradingSession is not null
+            && GradingSession.Slots.Any(s => s.Grade.Equals(_draggingCursor.Grade)))
+        {
+            GradingSession.MoveCutoff(_draggingCursor.Grade, clampedScore, this);
+        }
         e.Handled = true;
     }
 

--- a/Dotsesses/UI/ViolinPlotControl.axaml.cs
+++ b/Dotsesses/UI/ViolinPlotControl.axaml.cs
@@ -943,8 +943,13 @@ public partial class ViolinPlotControl : UserControl
         // applies canonical out-of-range bounds (issue #9 / Q3: -1, +5);
         // rejected moves leave the cursor at its last valid position,
         // and the mirror sync in MainWindowViewModel updates vm.Cursors
-        // on success.
-        vm.GradingSession?.MoveCutoff(_draggingBarbellCursor.Grade, clamped, this);
+        // on success. Guard non-draggable grades (catch-all, zero-range)
+        // since session.MoveCutoff throws ArgumentException for those.
+        if (vm.GradingSession is not null
+            && vm.GradingSession.Slots.Any(s => s.Grade.Equals(_draggingBarbellCursor.Grade)))
+        {
+            vm.GradingSession.MoveCutoff(_draggingBarbellCursor.Grade, clamped, this);
+        }
         e.Handled = true;
     }
 
@@ -1210,8 +1215,13 @@ public partial class ViolinPlotControl : UserControl
         // Slice 3: route the commit through GradingSession (issue #6
         // ADR-0010). Mirror sync in MainWindowViewModel reflects the
         // change back into vm.Cursors so existing rendering keeps
-        // working until issue #14's cleanup.
-        vm.GradingSession?.MoveCutoff(_draggingCursor.Grade, clamped, this);
+        // working until issue #14's cleanup. Guard non-draggable
+        // grades (catch-all, zero-range): session throws on those.
+        if (vm.GradingSession is not null
+            && vm.GradingSession.Slots.Any(s => s.Grade.Equals(_draggingCursor.Grade)))
+        {
+            vm.GradingSession.MoveCutoff(_draggingCursor.Grade, clamped, this);
+        }
         e.Handled = true;
     }
 


### PR DESCRIPTION
## Summary

Hot-fix for a crash introduced by slice 3 (#9 / PR #15). Dragging the **catch-all C** cursor on the dotplot (or the equivalent on the violin plot) crashes the app. The crash report (`~/Library/Logs/DiagnosticReports/Dotsesses-2026-05-07-150627.ips`) shows `SIGABRT` after a `DispatchManagedException`.

## Root cause

The legacy `Cursors` collection contains every grade from `DefaultCurveGenerator.GetAllGrades()` — 11 entries. `GradingSession.Slots` only has the draggable subset — 6 in production (catch-all and zero-range grades excluded).

Slice 3's drag handlers call `session.MoveCutoff(grade, …)` regardless of whether `grade` is in `session.Slots`. Per ADR-0011, the session throws `ArgumentException` for the catch-all and unknown grades. That exception was uncaught from the OxyPlot/Avalonia event pump → process abort.

The user's "drag the lowest cursor below 0" reproduces it: visually, the catch-all C sits below CPlus, so downward-drag-from-the-bottom picks it up.

## Fix

Each drag handler checks `session.Slots.Any(s.Grade == grade)` before calling `MoveCutoff`. Non-draggable grades silently no-op, matching ADR-0011 semantics. Three handlers patched:

- `MainWindowViewModel.OnDotplotMouseMove`
- `ViolinPlotControl.OnBarbellPointerMoved`
- `ViolinPlotControl.OnCursorColumnPointerMoved`

## Side-effect

The catch-all and zero-range grades are visible in the legacy UI but no longer visually move when dragged. Cleanup tracked in #14 (remove these grades from the legacy `Cursors` collection entirely so users can't grab them).

## Test plan

- [x] `dotnet test` — 173/173 passing (1 new regression witness in `MainWindowViewModelTests` that proves the discrepancy exists and `session.MoveCutoff` throws for non-draggable grades)
- [ ] Manual smoke test by maintainer: drag the lowest visible cursor on the dotplot — should refuse to move past `min−1` instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)