### PR TITLE
fix: structural catch-all derives from DefaultCurve; eliminate lower drag bound (#18)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -92,11 +92,15 @@ ItemsControl rebuild churn). Slots are read-only from the binding
 side — mutations go through the GradingSession's API.
 
 The **structural catch-all** Grade — the lowest-Order Grade in the
-session's initial cutoffs — has *no* CutoffSlot. It is always
+session's `DefaultCurve`, regardless of whether that Grade has a
+non-zero `CutoffCountRange` — has *no* CutoffSlot. It is always
 implicitly enabled, never draggable, and acts purely as a fallback
 for `GradeAssigner` (see ADR-0011). Calls to `MoveCutoff`,
 `EnableGrade`, or `DisableGrade` against the catch-all throw
-`ArgumentException`.
+`ArgumentException`. Every other Grade in `DefaultCurve` gets a
+Slot, including those that started with a zero target range — they
+sit in a fallback band below the data envelope and are draggable
+into the data range whenever the user wants to use them.
 
 **GradeBin**: The vertical stack of dots in the dotplot at one
 AggregateScore value. Students sharing an AggregateScore stack into the

--- a/Dotsesses.Tests/Services/StateServiceTests.cs
+++ b/Dotsesses.Tests/Services/StateServiceTests.cs
@@ -77,8 +77,10 @@ public class StateServiceTests : IDisposable
         Assert.Equal(2, loadedState.Version);
         Assert.Equal("original_source.xlsx", loadedState.SourceFile);
         Assert.Equal(2, loadedState.Students.Count);
-        // Slots are A and B (C is the catch-all and is appended); 3 cursor entries total.
-        Assert.Equal(3, loadedState.Cursors.Count);
+        // Slots are A, B, C (post-#18 fix: catch-all is F, lowest in
+        // DefaultCurve). SaveAsync iterates Slots and appends the
+        // catch-all → 4 cursor entries total.
+        Assert.Equal(4, loadedState.Cursors.Count);
     }
 
     [Fact]

--- a/Dotsesses.Tests/UI/GradingSessionTests.cs
+++ b/Dotsesses.Tests/UI/GradingSessionTests.cs
@@ -105,27 +105,32 @@ public class GradingSessionTests
         // permits. The catch-all (or whichever worse neighbor is
         // enabled) is now the only floor, via OrderingViolation /
         // WouldOverlap.
-        //
-        // Fixture: A=450, B=250, C=50, F catch-all at 38. Disable C so
-        // B's worse neighbor is the catch-all directly.
         var session = TestFixtures.SessionForGrading();
         var slotB = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.B);
         session.DisableGrade(TestFixtures.GradeC);
 
-        // 39 is just above the catch-all (38). Pre-#18 this would have
-        // failed with OutOfRange because 39 < 42 (the old lower bound).
-        // Post-#18 it succeeds — neighbor spacing is satisfied.
-        var lowMove = session.MoveCutoff(slotB.Grade, 39, new object());
+        // Look up the catch-all's actual score from session state — its
+        // exact value depends on the fixture's data envelope and the
+        // legacy-matched fallback formula in GradingSession.
+        var catchAllScore = session.CurrentState.Cutoffs
+            .Single(c => c.Grade.LetterGrade == LetterGrade.F)
+            .Score;
+
+        // One above the catch-all: succeeds (neighbor spacing satisfied).
+        // This score is well below the prior OutOfRange floor (which
+        // was `min − 8 = 42` in the fixture), so passing here proves the
+        // floor is gone.
+        var lowMove = session.MoveCutoff(slotB.Grade, catchAllScore + 1, new object());
         Assert.True(lowMove.Success);
-        Assert.Equal(39, slotB.Score);
+        Assert.Equal(catchAllScore + 1, slotB.Score);
 
         // Same score as catch-all → WouldOverlap (not OutOfRange).
-        var atCatchAll = session.MoveCutoff(slotB.Grade, 38, new object());
+        var atCatchAll = session.MoveCutoff(slotB.Grade, catchAllScore, new object());
         Assert.False(atCatchAll.Success);
         Assert.Equal(CutoffMoveFailure.WouldOverlap, atCatchAll.Failure);
 
         // Below the catch-all → OrderingViolation (not OutOfRange).
-        var belowCatchAll = session.MoveCutoff(slotB.Grade, 37, new object());
+        var belowCatchAll = session.MoveCutoff(slotB.Grade, catchAllScore - 1, new object());
         Assert.False(belowCatchAll.Success);
         Assert.Equal(CutoffMoveFailure.OrderingViolation, belowCatchAll.Failure);
     }

--- a/Dotsesses.Tests/UI/GradingSessionTests.cs
+++ b/Dotsesses.Tests/UI/GradingSessionTests.cs
@@ -81,21 +81,6 @@ public class GradingSessionTests
     }
 
     [Fact]
-    public void MoveCutoff_BelowMinAggregateMinusMargin_FailsWithOutOfRange()
-    {
-        // Fixture: AggregateGrades 50..540 → min − 8 = 42 (issue #17).
-        var session = TestFixtures.SessionForGrading();
-        var slotB = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.B);
-        var stateBefore = session.LastChange.State;
-
-        var result = session.MoveCutoff(slotB.Grade, 0, new object());
-
-        Assert.False(result.Success);
-        Assert.Equal(CutoffMoveFailure.OutOfRange, result.Failure);
-        Assert.Same(stateBefore, session.LastChange.State);
-    }
-
-    [Fact]
     public void MoveCutoff_AtUpperBoundExactly_IsAccepted_OnePastFails()
     {
         // Fixture: max=540 → max+5=545 (inclusive). 546 is OutOfRange.
@@ -111,28 +96,38 @@ public class GradingSessionTests
     }
 
     [Fact]
-    public void MoveCutoff_AtLowerBoundExactly_IsAccepted_OnePastFails()
+    public void MoveCutoff_HasNoLowerOutOfRangeBound_NeighborSpacingIsTheOnlyFloor()
     {
-        // Fixture: min=50 → min−8=42 (inclusive, issue #17).
-        // Cutoff state: A=450, B=250, C=50 (catch-all). To exercise the
-        // OutOfRange branch on the lower side we drag B (lowest slot) past
-        // 42 — but B's neighbor-spacing constraint is C (catch-all at 50),
-        // so the validation order is OutOfRange first (newScore < 42 →
-        // OutOfRange), neighbors-second.
+        // Issue #18 follow-up: the lower OutOfRange bound is gone so
+        // untargeted slots whose initial seed sits in the fallback band
+        // below `min - 8` can be dragged back up, AND a targeted slot
+        // can be dragged below `min - 8` whenever its lower neighbor
+        // permits. The catch-all (or whichever worse neighbor is
+        // enabled) is now the only floor, via OrderingViolation /
+        // WouldOverlap.
+        //
+        // Fixture: A=450, B=250, C=50, F catch-all at 38. Disable C so
+        // B's worse neighbor is the catch-all directly.
         var session = TestFixtures.SessionForGrading();
         var slotB = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.B);
+        session.DisableGrade(TestFixtures.GradeC);
 
-        // Disable the catch-all-adjacent neighbor implicitly by addressing
-        // the OutOfRange branch directly: pass a score below the bound and
-        // assert OutOfRange wins over OrderingViolation. ValidateMove
-        // checks IsEnabled → OutOfRange → neighbors, in that order.
-        var oneUnderBound = session.MoveCutoff(slotB.Grade, 41, new object());
-        Assert.False(oneUnderBound.Success);
-        Assert.Equal(CutoffMoveFailure.OutOfRange, oneUnderBound.Failure);
+        // 39 is just above the catch-all (38). Pre-#18 this would have
+        // failed with OutOfRange because 39 < 42 (the old lower bound).
+        // Post-#18 it succeeds — neighbor spacing is satisfied.
+        var lowMove = session.MoveCutoff(slotB.Grade, 39, new object());
+        Assert.True(lowMove.Success);
+        Assert.Equal(39, slotB.Score);
 
-        // 42 itself sits below the catch-all (50), so it fails neighbor
-        // ordering — but we've shown 41 fails as OutOfRange specifically,
-        // proving the lower bound has moved from 49 to 42.
+        // Same score as catch-all → WouldOverlap (not OutOfRange).
+        var atCatchAll = session.MoveCutoff(slotB.Grade, 38, new object());
+        Assert.False(atCatchAll.Success);
+        Assert.Equal(CutoffMoveFailure.WouldOverlap, atCatchAll.Failure);
+
+        // Below the catch-all → OrderingViolation (not OutOfRange).
+        var belowCatchAll = session.MoveCutoff(slotB.Grade, 37, new object());
+        Assert.False(belowCatchAll.Success);
+        Assert.Equal(CutoffMoveFailure.OrderingViolation, belowCatchAll.Failure);
     }
 
     [Fact]

--- a/Dotsesses.Tests/UI/GradingSessionTests.cs
+++ b/Dotsesses.Tests/UI/GradingSessionTests.cs
@@ -389,6 +389,62 @@ public class GradingSessionTests
     }
 
     [Fact]
+    public void Slots_IncludeAllGradesFromDefaultCurveExceptStructuralCatchAll()
+    {
+        // Diagnostic for issue #17 follow-on: per ADR-0008/0011 the
+        // structural catch-all is the lowest-Order grade in the
+        // *DefaultCurve* — not the lowest in initial cutoffs. Every
+        // other grade in DefaultCurve gets a Slot, including those with
+        // zero-bound CutoffCountRange, so they can be enabled and
+        // dragged later (real grading flows: instructor enables a
+        // CMinus row that started as untargeted, expects to drag it).
+        //
+        // Fixture DefaultCurve: A(10,10), B(20,20), C(20,20), F(0,0).
+        // Lowest Order in DefaultCurve = F → F is catch-all.
+        // Expected Slots: [A, B, C] (3 entries). C, despite being the
+        // lowest *targeted* grade, is still a draggable slot.
+        var session = TestFixtures.SessionForGrading();
+
+        Assert.Equal(3, session.Slots.Count);
+        var slotGrades = session.Slots.Select(s => s.Grade).ToHashSet();
+        Assert.Contains(TestFixtures.GradeA, slotGrades);
+        Assert.Contains(TestFixtures.GradeB, slotGrades);
+        Assert.Contains(TestFixtures.GradeC, slotGrades);
+        Assert.DoesNotContain(TestFixtures.GradeF, slotGrades);
+    }
+
+    [Fact]
+    public void StructuralCatchAll_IsLowestOrderGradeInDefaultCurve_NotInitialCutoffs()
+    {
+        // The catch-all is the grade in EnabledGrades that has no Slot.
+        // In the fixture, that should be F — not C (which is currently
+        // the buggy choice because slice 1 derived catch-all from
+        // initial cutoffs after the zero-range filter dropped F).
+        var session = TestFixtures.SessionForGrading();
+        var slotGrades = session.Slots.Select(s => s.Grade).ToHashSet();
+        var catchAllGrade = session.CurrentState.EnabledGrades
+            .Single(g => !slotGrades.Contains(g));
+
+        Assert.Equal(LetterGrade.F, catchAllGrade.LetterGrade);
+    }
+
+    [Fact]
+    public void MoveCutoff_OnLowestTargetedGradeWhenItIsNotCatchAll_IsAccepted()
+    {
+        // C is the lowest *targeted* grade in the fixture (lowest with
+        // non-zero range) but the structural catch-all is F. So C must
+        // be a draggable slot. MoveCutoff on it should succeed.
+        var session = TestFixtures.SessionForGrading();
+        var slotC = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.C);
+        var validScore = slotC.Score + 5;
+
+        var result = session.MoveCutoff(slotC.Grade, validScore, new object());
+
+        Assert.True(result.Success);
+        Assert.Equal(validScore, slotC.Score);
+    }
+
+    [Fact]
     public void CurrentState_FiresPropertyChangedAlongsideLastChange()
     {
         var session = TestFixtures.SessionForGrading();

--- a/Dotsesses.Tests/UI/GradingSessionTests.cs
+++ b/Dotsesses.Tests/UI/GradingSessionTests.cs
@@ -138,12 +138,13 @@ public class GradingSessionTests
     [Fact]
     public void MoveCutoff_OnStructuralCatchAll_ThrowsArgumentException()
     {
-        // Arrange — in this fixture C is the structural catch-all (lowest Order in initial cutoffs)
+        // Per ADR-0011 the catch-all is the lowest-Order grade in
+        // DefaultCurve. Fixture: DefaultCurve = [A, B, C, F] → F is
+        // the catch-all (never draggable).
         var session = TestFixtures.SessionForGrading();
 
-        // Act & Assert — caller is asking for something the API doesn't support
         Assert.Throws<ArgumentException>(() =>
-            session.MoveCutoff(TestFixtures.GradeC, 100, new object()));
+            session.MoveCutoff(TestFixtures.GradeF, 100, new object()));
     }
 
     [Fact]
@@ -275,19 +276,21 @@ public class GradingSessionTests
     [Fact]
     public void DisableGrade_OnStructuralCatchAll_ThrowsArgumentException()
     {
+        // F is the catch-all per ADR-0011 (lowest-Order in DefaultCurve).
         var session = TestFixtures.SessionForGrading();
 
         Assert.Throws<ArgumentException>(() =>
-            session.DisableGrade(TestFixtures.GradeC));
+            session.DisableGrade(TestFixtures.GradeF));
     }
 
     [Fact]
     public void EnableGrade_OnStructuralCatchAll_ThrowsArgumentException()
     {
+        // F is the catch-all per ADR-0011 (lowest-Order in DefaultCurve).
         var session = TestFixtures.SessionForGrading();
 
         Assert.Throws<ArgumentException>(() =>
-            session.EnableGrade(TestFixtures.GradeC));
+            session.EnableGrade(TestFixtures.GradeF));
     }
 
     [Fact]

--- a/Dotsesses/UI/GradingSession.cs
+++ b/Dotsesses/UI/GradingSession.cs
@@ -25,15 +25,19 @@ public sealed class GradingSession : ObservableObject
     private int _catchAllScore;
     private GradingStateChange _lastChange = null!;
 
-    // Asymmetric margin around the AggregateGrade envelope: cursors
-    // can sit well below the lowest student score (so the lowest
-    // enabled cursor has room to drop further when lower grades are
-    // disabled — e.g. pushing the catch-all band so a data-floor
-    // student still falls into a real letter grade) and above the
-    // highest score (so the A boundary can be pushed past the top
-    // scorer to make A unattainable). Slice 3 of issue #6 used
-    // [-1, +5]; issue #17 widened the lower margin to -8 after a
-    // smoke-test showed -1 was too tight in real grading flows.
+    // Asymmetric drag bounds: only the upper side has an `OutOfRange`
+    // limit (max + 5, so A can be pushed past the top scorer to make A
+    // unattainable). The lower side has no `OutOfRange` floor — issue
+    // #18 surfaced that untargeted slot grades start in a fallback band
+    // below `minStudentScore - ScoreBoundsMarginBelow`, so a hard lower
+    // bound traps them out-of-reach. The catch-all (or whichever worse
+    // neighbor is enabled) is now the only floor on cursor drag, via
+    // the existing `OrderingViolation` / `WouldOverlap` checks.
+    //
+    // `_minScore` is still computed for `CursorPlacementCalculator.PlaceNewCursor`
+    // (used by `EnableGrade` to seat re-enabled grades) but no longer
+    // affects `ValidateMove`. Slice 3 of #6 used [-1, +5]; issue #17
+    // widened to [-8, +5]; issue #18 dropped the lower bound entirely.
     private const int ScoreBoundsMarginBelow = 8;
     private const int ScoreBoundsMarginAbove = 5;
 
@@ -341,7 +345,9 @@ public sealed class GradingSession : ObservableObject
         if (!slot.IsEnabled)
             return CutoffMoveResult.Fail(CutoffMoveFailure.GradeNotEnabled);
 
-        if (newScore < _minScore || newScore > _maxScore)
+        // Only the upper side enforces OutOfRange. See the
+        // `ScoreBoundsMargin*` comment for why the lower bound is open.
+        if (newScore > _maxScore)
             return CutoffMoveResult.Fail(CutoffMoveFailure.OutOfRange);
 
         var (better, worse) = FindAdjacentEnabledCutoffs(slot.Grade);

--- a/Dotsesses/UI/GradingSession.cs
+++ b/Dotsesses/UI/GradingSession.cs
@@ -82,8 +82,34 @@ public sealed class GradingSession : ObservableObject
         _minScore = classAssessment.Assessments.Min(a => a.AggregateGrade) - ScoreBoundsMarginBelow;
         _maxScore = classAssessment.Assessments.Max(a => a.AggregateGrade) + ScoreBoundsMarginAbove;
 
+        // Catch-all is the lowest-Order grade in DefaultCurve, regardless
+        // of targeting (ADR-0011). Issue #18 corrected this from slice 1's
+        // mistaken "lowest-Order in initial cutoffs" — the previous logic
+        // dropped zero-range grades before picking the catch-all, leaving
+        // production grades like CMinus, DPlus, D, F structurally absent
+        // from `Slots` and undraggable.
+        var allCurveGrades = classAssessment.DefaultCurve
+            .Select(r => r.Grade)
+            .OrderBy(g => g.Order)
+            .ToList();
+
+        if (allCurveGrades.Count < 2)
+        {
+            throw new InvalidOperationException(
+                "DefaultCurve must contain at least two grades " +
+                "(one structural catch-all plus at least one slot).");
+        }
+
+        _structuralCatchAll = allCurveGrades[^1];
+        var slotGrades = allCurveGrades
+            .Where(g => !g.Equals(_structuralCatchAll))
+            .ToList();
+
+        // Targeted slots get positions from InitialCutoffCalculator
+        // (curves with non-zero range, excluding the catch-all).
         var midpointCurve = classAssessment.DefaultCurve
             .Where(r => r.LowerBound > 0 || r.UpperBound > 0)
+            .Where(r => !r.Grade.Equals(_structuralCatchAll))
             .Select(r => new CutoffCount(r.Grade, r.Midpoint))
             .OrderBy(c => c.Grade.Order)
             .ToList();
@@ -91,30 +117,60 @@ public sealed class GradingSession : ObservableObject
         if (midpointCurve.Count == 0)
         {
             throw new InvalidOperationException(
-                "DefaultCurve has no targeted grades (all ranges are zero); " +
-                "GradingSession requires at least one targeted grade.");
+                "DefaultCurve has no targeted slot grades (all non-catch-all " +
+                "ranges are zero); GradingSession requires at least one " +
+                "targeted slot grade to seed initial positions.");
         }
 
-        var initialCutoffs = _initialCutoffCalculator
+        var seededCutoffs = _initialCutoffCalculator
             .Calculate(classAssessment.Assessments, midpointCurve)
-            .OrderBy(c => c.Grade.Order)
+            .ToDictionary(c => c.Grade);
+
+        // Untargeted slots (zero-range CutoffCountRange) get fallback
+        // positions in a band below the data envelope — visible and
+        // draggable but not positioned to catch students by default.
+        // Mirrors the legacy SeedCursorsFromDefaults "Second pass" so
+        // the legacy `_cursors` mirror sync stays consistent during
+        // the slice-3 transition.
+        var minStudentScore = classAssessment.Assessments.Min(a => a.AggregateGrade);
+        var maxStudentScore = classAssessment.Assessments.Max(a => a.AggregateGrade);
+        var fallbackScoreRange = maxStudentScore - minStudentScore;
+        var fallbackBaseScore = (int)Math.Round(minStudentScore - fallbackScoreRange * 0.25);
+
+        var untargetedSlotGrades = slotGrades
+            .Where(g => !seededCutoffs.ContainsKey(g))
+            .OrderBy(g => g.Order)
             .ToList();
 
-        // The lowest-Order grade in the initial cutoffs is the structural
-        // catch-all (Q1=C): it has no Slot and is always implicitly
-        // enabled. Per ADR-0008, this designation is fixed at construction.
-        _structuralCatchAll = initialCutoffs[^1].Grade;
-        _catchAllScore = initialCutoffs[^1].Score;
+        var fallbackScores = new Dictionary<Grade, int>();
+        for (int i = 0; i < untargetedSlotGrades.Count; i++)
+        {
+            // Lower-Order grades sit higher in the fallback band so the
+            // overall (Order, Score) relationship stays monotonic
+            // descending across all slots.
+            fallbackScores[untargetedSlotGrades[i]] = fallbackBaseScore - i * DefaultCursorSpacing;
+        }
 
         _slots = new ObservableCollection<CutoffSlot>(
-            initialCutoffs
-                .Where(c => !c.Grade.Equals(_structuralCatchAll))
-                .Select(c => new CutoffSlot(c.Grade, c.Score, isEnabled: true)));
+            slotGrades
+                .OrderBy(g => g.Order)
+                .Select(g => new CutoffSlot(
+                    g,
+                    seededCutoffs.TryGetValue(g, out var seeded) ? seeded.Score : fallbackScores[g],
+                    isEnabled: true)));
 
         Slots = new ReadOnlyObservableCollection<CutoffSlot>(_slots);
 
-        var enabledGrades = initialCutoffs
-            .Select(c => c.Grade)
+        // Catch-all sits below the lowest slot so it remains the
+        // assignment fallback (until a user drags a slot below it,
+        // which ValidateMove rejects via OrderingViolation).
+        _catchAllScore = _slots.Min(s => s.Score) - DefaultCursorSpacing;
+
+        var initialCutoffs = BuildCurrentCutoffs();
+        var enabledGrades = _slots
+            .Where(s => s.IsEnabled)
+            .Select(s => s.Grade)
+            .Append(_structuralCatchAll)
             .ToHashSet();
 
         var counts = _cutoffCountCalculator
@@ -129,6 +185,12 @@ public sealed class GradingSession : ObservableObject
 
         _lastChange = new GradingStateChange(Originator: null, State: initialState);
     }
+
+    // Matches CursorPlacementCalculator's DefaultCursorSpacing — the
+    // minimum safe gap between adjacent cutoffs that still respects
+    // ordering. Used to space the fallback band for untargeted slots
+    // and to position the catch-all below them.
+    private const int DefaultCursorSpacing = 12;
 
     public CutoffMoveResult CanMoveCutoff(Grade grade, int newScore)
     {

--- a/Dotsesses/UI/GradingSession.cs
+++ b/Dotsesses/UI/GradingSession.cs
@@ -133,26 +133,51 @@ public sealed class GradingSession : ObservableObject
         // Untargeted slots (zero-range CutoffCountRange) get fallback
         // positions in a band below the data envelope — visible and
         // draggable but not positioned to catch students by default.
-        // Mirrors the legacy SeedCursorsFromDefaults "Second pass" so
-        // the legacy `_cursors` mirror sync stays consistent during
-        // the slice-3 transition.
+        // Match the legacy SeedCursorsFromDefaults "Second pass"
+        // algorithm exactly so the initial visible positions agree
+        // between the legacy `_cursors` collection and `session.Slots`.
+        // Otherwise the mirror sync after the first drag yanks
+        // untargeted cursors from their legacy positions to session
+        // positions, producing a visible "jump."
+        //
+        // Legacy stack order (descending Order):
+        //   i=0 → catch-all (basePosition)
+        //   i=1 → next-lowest grade (basePosition + spacing)
+        //   i=2 → ...                  (basePosition + 2*spacing)
+        //   ...
         var minStudentScore = classAssessment.Assessments.Min(a => a.AggregateGrade);
         var maxStudentScore = classAssessment.Assessments.Max(a => a.AggregateGrade);
         var fallbackScoreRange = maxStudentScore - minStudentScore;
         var fallbackBaseScore = (int)Math.Round(minStudentScore - fallbackScoreRange * 0.25);
 
+        // Spacing formula copied verbatim from
+        // MainWindowViewModel.SeedCursorsFromDefaults so the two
+        // placements match. When issue #14's cleanup deletes the
+        // legacy path, this formula can be replaced with something
+        // simpler (it currently encodes a 400px-plot pixel
+        // assumption, which is a layout detail that doesn't belong
+        // here).
+        const double BarbellHandlePixels = 8.0;
+        const double SpacingPixels = BarbellHandlePixels * 2;
+        const double EstimatedPlotHeight = 400.0 * 0.8;
+        var fallbackCursorSpacing = (int)Math.Ceiling(
+            SpacingPixels * fallbackScoreRange / Math.Max(1, EstimatedPlotHeight));
+
         var untargetedSlotGrades = slotGrades
             .Where(g => !seededCutoffs.ContainsKey(g))
-            .OrderBy(g => g.Order)
+            .OrderByDescending(g => g.Order)
             .ToList();
 
         var fallbackScores = new Dictionary<Grade, int>();
         for (int i = 0; i < untargetedSlotGrades.Count; i++)
         {
-            // Lower-Order grades sit higher in the fallback band so the
-            // overall (Order, Score) relationship stays monotonic
-            // descending across all slots.
-            fallbackScores[untargetedSlotGrades[i]] = fallbackBaseScore - i * DefaultCursorSpacing;
+            // i=0 is reserved for the catch-all; slot positions start
+            // at i=1 and stack upward with descending Order. So the
+            // highest-Order untargeted slot gets the lowest score
+            // above the catch-all, and the lowest-Order untargeted
+            // slot tops the fallback band.
+            fallbackScores[untargetedSlotGrades[i]] =
+                fallbackBaseScore + (i + 1) * fallbackCursorSpacing;
         }
 
         _slots = new ObservableCollection<CutoffSlot>(
@@ -165,10 +190,12 @@ public sealed class GradingSession : ObservableObject
 
         Slots = new ReadOnlyObservableCollection<CutoffSlot>(_slots);
 
-        // Catch-all sits below the lowest slot so it remains the
-        // assignment fallback (until a user drags a slot below it,
-        // which ValidateMove rejects via OrderingViolation).
-        _catchAllScore = _slots.Min(s => s.Score) - DefaultCursorSpacing;
+        // Catch-all sits at the legacy "i=0" position — basePosition.
+        // This stays below all slot positions whether or not there are
+        // untargeted slots, since untargeted slots stack above
+        // basePosition and targeted slots are seeded inside the data
+        // envelope (above basePosition by construction).
+        _catchAllScore = fallbackBaseScore;
 
         var initialCutoffs = BuildCurrentCutoffs();
         var enabledGrades = _slots
@@ -189,12 +216,6 @@ public sealed class GradingSession : ObservableObject
 
         _lastChange = new GradingStateChange(Originator: null, State: initialState);
     }
-
-    // Matches CursorPlacementCalculator's DefaultCursorSpacing — the
-    // minimum safe gap between adjacent cutoffs that still respects
-    // ordering. Used to space the fallback band for untargeted slots
-    // and to position the catch-all below them.
-    private const int DefaultCursorSpacing = 12;
 
     public CutoffMoveResult CanMoveCutoff(Grade grade, int newScore)
     {

--- a/Dotsesses/UI/MainWindowViewModel.cs
+++ b/Dotsesses/UI/MainWindowViewModel.cs
@@ -140,12 +140,37 @@ public partial class MainWindowViewModel : ViewModelBase
     private void SyncCursorsFromSession()
     {
         if (GradingSession is null) return;
-        foreach (var slot in GradingSession.Slots)
+
+        // Atomic mirror: suppress per-cursor PropertyChanged reactions
+        // during the loop so RecalculateGradeCounts (called from
+        // OnCursorPropertyChanged) doesn't see a mid-loop mixed state
+        // where some cursors have new session values and others still
+        // hold legacy values — that combination can violate
+        // GradeAssigner's ordering invariant. Issue #18.
+        var wasUpdating = _isUpdatingCursorsFromSubscription;
+        _isUpdatingCursorsFromSubscription = true;
+        try
         {
-            var cursor = Cursors.FirstOrDefault(c => c.Grade.Equals(slot.Grade));
-            if (cursor is null) continue;
-            if (cursor.Score != slot.Score) cursor.Score = slot.Score;
-            if (cursor.IsEnabled != slot.IsEnabled) cursor.IsEnabled = slot.IsEnabled;
+            foreach (var slot in GradingSession.Slots)
+            {
+                var cursor = Cursors.FirstOrDefault(c => c.Grade.Equals(slot.Grade));
+                if (cursor is null) continue;
+                if (cursor.Score != slot.Score) cursor.Score = slot.Score;
+                if (cursor.IsEnabled != slot.IsEnabled) cursor.IsEnabled = slot.IsEnabled;
+            }
+        }
+        finally
+        {
+            _isUpdatingCursorsFromSubscription = wasUpdating;
+        }
+
+        // Run the downstream pipeline once with the fully-mirrored state.
+        // Guard DotplotModel for the test factory path where it may be null.
+        if (DotplotModel is not null)
+        {
+            UpdateCursors();
+            RecalculateGradeCounts();
+            HasUnsavedChanges = true;
         }
     }
 

--- a/docs/adr/0011-slots-collection-excludes-structural-catchall.md
+++ b/docs/adr/0011-slots-collection-excludes-structural-catchall.md
@@ -1,13 +1,23 @@
 # `GradingSession.Slots` excludes the structural catch-all Grade
 
 The `Slots` collection on a `GradingSession` exposes a `CutoffSlot`
-for every Grade in the session's structural set **except** the
-structural catch-all — i.e. the lowest-Order Grade in the initial
-cutoffs at construction time. The catch-all has no slot, is always
-present in `GradingState.EnabledGrades`, and cannot be moved,
-disabled, or re-enabled. Its score lives on a private field inside
-the session and is only mutated by `LoadCutoffs` /
-`ReseedFromDefaults` / a reseed inside `EnableGrade`.
+for every Grade in the session's `DefaultCurve` **except** the
+structural catch-all — the lowest-Order Grade in `DefaultCurve` at
+construction time, regardless of whether that Grade has a non-zero
+`CutoffCountRange`. The catch-all has no slot, is always present
+in `GradingState.EnabledGrades`, and cannot be moved, disabled, or
+re-enabled. Its score lives on a private field inside the session
+and is only mutated by `LoadCutoffs` / `ReseedFromDefaults` / a
+reseed inside `EnableGrade`.
+
+> **2026-05-07 (issue #18)**: Earlier wording said "lowest-Order in
+> the *initial cutoffs*." That implementation post-filtered the
+> curve and dropped zero-range grades before picking the catch-all,
+> so production (where CMinus, DPlus, D, F all have zero range)
+> ended up with `C` as the catch-all and four grades structurally
+> absent from `Slots`. The intended structure has always been
+> "lowest-Order in `DefaultCurve`" — issue #18 corrected the code
+> and this paragraph to match.
 
 ## Why
 


### PR DESCRIPTION
## Summary

Closes #18. Three coordinated bug fixes plus a RED-test commit, all converging on the user-facing symptom that **untargeted grade cursors weren't draggable** in production grading flows.

## Commits

1. `2c544e3` — RED diagnostic tests that lock the expected slot membership and catch-all identity.
2. `7cbab7a` — derive structural catch-all from `DefaultCurve` (lowest-Order grade in the *whole* curve), not from the post-filter initial cutoffs. Untargeted slots (zero-range CutoffCountRange) now appear in `Slots` and start `IsEnabled=true` with fallback positions below the data envelope.
3. `d970a0c` — eliminate the lower OutOfRange bound. Without it, untargeted slots that initially seed below `min - 8` were trapped: session validation rejected every drag attempt, leaving the cursors visible-but-stuck. The catch-all (or whichever lower neighbor is enabled) is now the only floor, via the existing `OrderingViolation` / `WouldOverlap` checks.
4. `02dbfb9` — match legacy `SeedCursorsFromDefaults` "Second pass" placement exactly. Without this, mirror sync after the first drag yanked every untargeted cursor at once because session positions didn't agree with legacy positions at construction.

## Why these go together

Each fix on its own surfaces a new symptom of the same root cause: slice 1's `_structuralCatchAll = initialCutoffs[^1].Grade` confused "lowest in initial cutoffs" with "lowest in DefaultCurve." Per ADR-0011 the catch-all has always been intended as the latter — the wording in the original ADR was wrong, fixed here.

## Test plan

- [x] `dotnet test` — 176/176 passing
- [x] RED diagnostics from `2c544e3` are now GREEN
- [x] Three slice-1 catch-all-throws tests updated to use `GradeF` (was `GradeC`); `StateServiceTests.LoadAsync_ReturnsCorrectState` cursor count `3 → 4`
- [x] New `MoveCutoff_HasNoLowerOutOfRangeBound_NeighborSpacingIsTheOnlyFloor` locks the lower-bound-removed contract
- [x] **Manual smoke test by maintainer** (already done): all grade cursors are draggable, including the untargeted ones; first drag doesn't make others jump; lower-bound trap is gone

## Side effects

- Session `Slots` count grows from 6 → 10 in production (was missing the four untargeted grades).
- `SavedState.Cursors` count grows correspondingly on save (mirrors all slot states + catch-all).
- Backward-compat: existing `.dots` files load unchanged; missing slot entries fall back to construction defaults via `LoadCutoffs`'s tolerant lookup.

## Carry-over tech debt

- The pixel-derived spacing formula in `GradingSession`'s constructor (`16 * scoreRange / 320`) is copied verbatim from `MainWindowViewModel.SeedCursorsFromDefaults` so the two placements agree at construction. The duplication is a slice-3 transitional artifact — when issue #14 deletes the legacy `_cursors` collection, the formula can move out of session entirely (it encodes a layout assumption that doesn't belong in domain code).
- TD007 — already noted in the previous PR — partially undone here: the lower OutOfRange floor is now intentionally absent. The catch-all + neighbor spacing keeps things from going arbitrarily negative in practice.

## Docs

- `CONTEXT.md` — catch-all paragraph rewritten to say "lowest-Order in `DefaultCurve`."
- `docs/adr/0011-slots-collection-excludes-structural-catchall.md` — amended with a 2026-05-07 correction note crediting #18.

Closes #18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)