### PR TITLE
feat(ComplianceGrid): extract ComplianceGridViewModel (slice 4 of #6)

### DIFF
--- a/Dotsesses.Tests/UI/ComplianceGridViewModelTests.cs
+++ b/Dotsesses.Tests/UI/ComplianceGridViewModelTests.cs
@@ -1,0 +1,160 @@
+namespace Dotsesses.Tests.UI;
+
+using System.Linq;
+using Dotsesses.Models;
+using Dotsesses.Tests.Fixtures;
+using Dotsesses.UI;
+using Xunit;
+
+/// <summary>
+/// Slice 4 / issue #10: ComplianceGridViewModel owns the compliance
+/// grid and subscribes to GradingSession.
+/// </summary>
+public class ComplianceGridViewModelTests
+{
+    private static ComplianceGridViewModel BuildVm(out GradingSession session)
+    {
+        session = TestFixtures.SessionForGrading();
+        var classAssessment = TestFixtures.ClassAssessmentForGrading();
+        return new ComplianceGridViewModel(classAssessment, session);
+    }
+
+    [Fact]
+    public void Constructor_BuildsOneRowPerDefaultCurveGrade()
+    {
+        // The fixture's DefaultCurve has 4 entries: A, B, C, F (catch-all).
+        var vm = BuildVm(out _);
+
+        Assert.Equal(4, vm.Rows.Count);
+        Assert.Equal(
+            new[] { LetterGrade.A, LetterGrade.B, LetterGrade.C, LetterGrade.F },
+            vm.Rows.Select(r => r.Grade.LetterGrade).ToArray());
+    }
+
+    [Fact]
+    public void Constructor_PopulatesTargetRangeFromDefaultCurve()
+    {
+        var vm = BuildVm(out _);
+
+        Assert.Equal((10, 10), (vm.Rows[0].LowerTarget, vm.Rows[0].UpperTarget));
+        Assert.Equal((20, 20), (vm.Rows[1].LowerTarget, vm.Rows[1].UpperTarget));
+        Assert.Equal((20, 20), (vm.Rows[2].LowerTarget, vm.Rows[2].UpperTarget));
+        Assert.Equal((0, 0), (vm.Rows[3].LowerTarget, vm.Rows[3].UpperTarget));
+    }
+
+    [Fact]
+    public void Constructor_PopulatesInitialCount_FromSession()
+    {
+        var vm = BuildVm(out var session);
+
+        // Each row's count must match session.CurrentState.Counts on construction.
+        foreach (var row in vm.Rows)
+        {
+            var expected = session.CurrentState.Counts
+                .First(c => c.Grade.Equals(row.Grade)).Count;
+            Assert.Equal(expected, row.CurrentCount);
+        }
+    }
+
+    [Fact]
+    public void Constructor_PopulatesIsEnabled_FromSession()
+    {
+        // Fresh session: every slot enabled, catch-all enabled.
+        var vm = BuildVm(out _);
+
+        Assert.All(vm.Rows, r => Assert.True(r.IsEnabled));
+    }
+
+    [Fact]
+    public void MoveCutoff_OnSession_UpdatesCurrentCount()
+    {
+        var vm = BuildVm(out var session);
+        var slotA = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.A);
+
+        // Top fixture student is 540; push A past it (within the +5
+        // upper drag bound) so the A bin empties.
+        session.MoveCutoff(slotA.Grade, 545, originator: this);
+
+        var aRow = vm.Rows.First(r => r.Grade.LetterGrade == LetterGrade.A);
+        Assert.Equal(0, aRow.CurrentCount);
+    }
+
+    [Fact]
+    public void DisableGrade_OnSession_FlipsRowIsEnabledFalse()
+    {
+        var vm = BuildVm(out var session);
+        var slotB = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.B);
+
+        session.DisableGrade(slotB.Grade);
+
+        var bRow = vm.Rows.First(r => r.Grade.LetterGrade == LetterGrade.B);
+        Assert.False(bRow.IsEnabled);
+    }
+
+    [Fact]
+    public void Toggle_RowToDisabled_CallsSessionDisableGrade()
+    {
+        var vm = BuildVm(out var session);
+        var bRow = vm.Rows.First(r => r.Grade.LetterGrade == LetterGrade.B);
+
+        Assert.True(bRow.IsEnabled);
+        bRow.IsEnabled = false; // simulate user toggling the checkbox
+
+        var slotB = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.B);
+        Assert.False(slotB.IsEnabled);
+    }
+
+    [Fact]
+    public void Toggle_RowToEnabled_CallsSessionEnableGrade()
+    {
+        var vm = BuildVm(out var session);
+        var bRow = vm.Rows.First(r => r.Grade.LetterGrade == LetterGrade.B);
+
+        // Disable first so we can re-enable.
+        session.DisableGrade(bRow.Grade);
+        Assert.False(bRow.IsEnabled);
+
+        bRow.IsEnabled = true;
+
+        var slotB = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.B);
+        Assert.True(slotB.IsEnabled);
+    }
+
+    [Fact]
+    public void Toggle_OnCatchAllRow_DoesNotThrow_AndDoesNotMutateSession()
+    {
+        // The catch-all is structurally always enabled (ADR-0011) and has
+        // no draggable slot — toggling its row must be inert, not throw
+        // ArgumentException out of session.DisableGrade.
+        var vm = BuildVm(out var session);
+        var fRow = vm.Rows.First(r => r.Grade.LetterGrade == LetterGrade.F);
+
+        var ex = Record.Exception(() => fRow.IsEnabled = false);
+
+        Assert.Null(ex);
+        // Catch-all stays in EnabledGrades regardless of the row flag.
+        Assert.Contains(session.CurrentState.EnabledGrades, g => g.LetterGrade == LetterGrade.F);
+    }
+
+    [Fact]
+    public void SyncFromSession_DoesNotReentrantlyToggle()
+    {
+        // session.LastChange fires → SyncFromSession sets row.IsEnabled →
+        // row's onEnabledChanged callback runs → must NOT call session
+        // back, otherwise we get a feedback loop. Drive a session change
+        // and assert no extra LastChange events fire from the sync.
+        var vm = BuildVm(out var session);
+        var slotA = session.Slots.First(s => s.Grade.LetterGrade == LetterGrade.A);
+
+        int extraEmissions = 0;
+        session.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(GradingSession.LastChange)) extraEmissions++;
+        };
+
+        session.MoveCutoff(slotA.Grade, slotA.Score - 5, originator: this);
+
+        // Exactly one LastChange (the MoveCutoff) — no echo from the sync.
+        Assert.Equal(1, extraEmissions);
+    }
+}

--- a/Dotsesses.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/Dotsesses.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -108,8 +108,8 @@ public class MainWindowViewModelTests
         var viewModel = CreateViewModel();
 
         // Assert
-        Assert.NotNull(viewModel.ComplianceRows);
-        Assert.Equal(11, viewModel.ComplianceRows.Count); // All grades A through F (including C-, D+)
+        Assert.NotNull(viewModel.ComplianceGrid);
+        Assert.Equal(11, viewModel.ComplianceGrid.Rows.Count); // All grades A through F (including C-, D+)
     }
 
     [Fact]
@@ -121,7 +121,7 @@ public class MainWindowViewModelTests
         // Assert — All grades (A through F) are enabled by default. The
         // catch-all (F in production) is structurally always enabled and
         // not present in Slots; assert via session.CurrentState.EnabledGrades.
-        var fGrade = viewModel.ComplianceRows.FirstOrDefault(r => r.Grade.LetterGrade == LetterGrade.F);
+        var fGrade = viewModel.ComplianceGrid!.Rows.FirstOrDefault(r => r.Grade.LetterGrade == LetterGrade.F);
         Assert.NotNull(fGrade);
         Assert.True(fGrade.IsEnabled, "F compliance row should be enabled by default");
 
@@ -220,7 +220,7 @@ public class MainWindowViewModelTests
         // Arrange
         var vm = CreateViewModel();
         var studentCount = vm.ClassAssessment.Assessments.Count;
-        var beforeSum = vm.ComplianceRows.Sum(r => r.CurrentCount);
+        var beforeSum = vm.ComplianceGrid!.Rows.Sum(r => r.CurrentCount);
         var scores = vm.ClassAssessment.Assessments.First().Scores;
         var newSelections = BuildSelections(scores);
 
@@ -229,7 +229,7 @@ public class MainWindowViewModelTests
 
         // Assert — total count across compliance rows is preserved (== student count),
         // proving grade counts were recomputed without losing any students.
-        var afterSum = vm.ComplianceRows.Sum(r => r.CurrentCount);
+        var afterSum = vm.ComplianceGrid!.Rows.Sum(r => r.CurrentCount);
         Assert.Equal(studentCount, beforeSum);
         Assert.Equal(studentCount, afterSum);
     }

--- a/Dotsesses/UI/ComplianceGridViewModel.cs
+++ b/Dotsesses/UI/ComplianceGridViewModel.cs
@@ -1,0 +1,99 @@
+namespace Dotsesses.UI;
+
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Dotsesses.Models;
+
+/// <summary>
+/// Owns the Compliance grid (one row per Grade in the DefaultCurve)
+/// and stays in sync with a <see cref="GradingSession"/>: target ranges
+/// are read once from <see cref="ClassAssessment.DefaultCurve"/>, while
+/// counts and enable state propagate from every
+/// <see cref="GradingSession.LastChange"/>.
+///
+/// Toggling <see cref="ComplianceRowViewModel.IsEnabled"/> on a slot row
+/// dispatches to <see cref="GradingSession.EnableGrade"/> /
+/// <see cref="GradingSession.DisableGrade"/>. The structural catch-all
+/// row (ADR-0011) has no slot and is always enabled, so its toggle is
+/// inert — the next session sync flips it back to <c>true</c>.
+/// </summary>
+public sealed class ComplianceGridViewModel : ObservableObject
+{
+    private readonly GradingSession _session;
+    private readonly HashSet<Grade> _slotGrades;
+    private readonly ObservableCollection<ComplianceRowViewModel> _rows = new();
+    private bool _isSyncingFromSession;
+
+    public ReadOnlyObservableCollection<ComplianceRowViewModel> Rows { get; }
+
+    public ComplianceGridViewModel(ClassAssessment classAssessment, GradingSession session)
+    {
+        ArgumentNullException.ThrowIfNull(classAssessment);
+        ArgumentNullException.ThrowIfNull(session);
+
+        _session = session;
+        _slotGrades = session.Slots.Select(s => s.Grade).ToHashSet();
+        Rows = new ReadOnlyObservableCollection<ComplianceRowViewModel>(_rows);
+
+        var state = session.CurrentState;
+        foreach (var range in classAssessment.DefaultCurve.OrderBy(r => r.Grade.Order))
+        {
+            var grade = range.Grade;
+            var count = state.Counts.FirstOrDefault(c => c.Grade.Equals(grade))?.Count ?? 0;
+            var isEnabled = state.EnabledGrades.Contains(grade);
+
+            _rows.Add(new ComplianceRowViewModel(
+                grade,
+                range.LowerBound,
+                range.UpperBound,
+                count,
+                isEnabled,
+                onEnabledChanged: () => OnRowToggled(grade)));
+        }
+
+        session.PropertyChanged += OnSessionPropertyChanged;
+    }
+
+    private void OnSessionPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(GradingSession.LastChange)) return;
+        SyncFromSession();
+    }
+
+    private void SyncFromSession()
+    {
+        _isSyncingFromSession = true;
+        try
+        {
+            var state = _session.CurrentState;
+            foreach (var row in _rows)
+            {
+                row.IsEnabled = state.EnabledGrades.Contains(row.Grade);
+                var count = state.Counts.FirstOrDefault(c => c.Grade.Equals(row.Grade))?.Count ?? 0;
+                row.CurrentCount = count;
+            }
+        }
+        finally
+        {
+            _isSyncingFromSession = false;
+        }
+    }
+
+    private void OnRowToggled(Grade grade)
+    {
+        if (_isSyncingFromSession) return;
+        if (!_slotGrades.Contains(grade)) return; // catch-all row is inert
+
+        var row = _rows.First(r => r.Grade.Equals(grade));
+        var slot = _session.Slots.First(s => s.Grade.Equals(grade));
+        if (row.IsEnabled && !slot.IsEnabled)
+        {
+            _session.EnableGrade(grade, this);
+        }
+        else if (!row.IsEnabled && slot.IsEnabled)
+        {
+            _session.DisableGrade(grade, this);
+        }
+    }
+}

--- a/Dotsesses/UI/MainWindow.axaml
+++ b/Dotsesses/UI/MainWindow.axaml
@@ -277,7 +277,7 @@
                                 </Grid>
 
                                 <!-- Data Rows -->
-                                <ItemsControl Grid.Row="1" ItemsSource="{Binding ComplianceRows}">
+                                <ItemsControl Grid.Row="1" ItemsSource="{Binding ComplianceGrid.Rows}">
                                     <ItemsControl.ItemTemplate>
                                         <DataTemplate x:DataType="vm:ComplianceRowViewModel">
                                             <Grid ColumnDefinitions="40,50,40,50" Margin="0,1" IsVisible="{Binding IsEnabled}">

--- a/Dotsesses/UI/MainWindow.axaml.cs
+++ b/Dotsesses/UI/MainWindow.axaml.cs
@@ -361,7 +361,7 @@ public partial class MainWindow : Window
                 violinPlotControl,
                 correlationPlotControl,
                 vm.PlotTabContainerViewModel,
-                vm.ComplianceRows,
+                vm.ComplianceGrid?.Rows ?? Enumerable.Empty<Dotsesses.UI.ComplianceRowViewModel>(),
                 className);
 
             // Show success message with option to open
@@ -510,7 +510,7 @@ public partial class MainWindow : Window
                     fileNameStem,
                     vm.ClassAssessment.Assessments,
                     vm.GradeAssigner,
-                    vm.ComplianceRows);
+                    vm.ComplianceGrid?.Rows ?? Enumerable.Empty<Dotsesses.UI.ComplianceRowViewModel>());
 
                 // Show success message
                 var successBox = MessageBoxManager.GetMessageBoxCustom(new MessageBoxCustomParams

--- a/Dotsesses/UI/MainWindowViewModel.cs
+++ b/Dotsesses/UI/MainWindowViewModel.cs
@@ -39,12 +39,13 @@ public partial class MainWindowViewModel : ViewModelBase
     private readonly HoverDelayService _hoverDelayService = null!;
     private readonly StateService _stateService = new();
 
-    private GradeAssigner _gradeAssigner = null!;
-
     /// <summary>
-    /// Gets the current grade assigner for export purposes.
+    /// Gets a fresh GradeAssigner built from the session's current
+    /// cutoffs. Used by drill-down lookup and export. Constructing
+    /// per call is cheap and removes the stale-cache risk that the
+    /// cursor-mirror era had.
     /// </summary>
-    public GradeAssigner GradeAssigner => _gradeAssigner;
+    public GradeAssigner GradeAssigner => new(GradingSession.CurrentState.Cutoffs);
 
     private CutoffSlot? _draggingCursor;
     private bool _isDraggingCursor;
@@ -76,7 +77,7 @@ public partial class MainWindowViewModel : ViewModelBase
     private PlotModel _dotplotModel = null!;
 
     [ObservableProperty]
-    private ObservableCollection<ComplianceRowViewModel> _complianceRows = null!;
+    private ComplianceGridViewModel? _complianceGrid;
 
     [ObservableProperty]
     private bool _isCompliancePaneOpen = true;
@@ -124,17 +125,17 @@ public partial class MainWindowViewModel : ViewModelBase
     public StateService StateService => _stateService;
 
     /// <summary>
-    /// Re-renders dotplot annotations and refreshes Compliance counts
-    /// from the session's current state. Invoked whenever the session
-    /// emits a LastChange notification (drag commit, enable/disable,
-    /// reseed, load).
+    /// Re-renders dotplot annotations from the session's current state.
+    /// Invoked whenever the session emits a LastChange notification
+    /// (drag commit, enable/disable, reseed, load). Compliance counts
+    /// flow through <see cref="ComplianceGridViewModel"/>'s own
+    /// subscription, not this method.
     /// </summary>
     private void OnSessionStateChanged()
     {
         if (GradingSession is null) return;
         if (DotplotModel is null) return; // Test factory path
 
-        RecalculateGradeCounts();
         UpdateCursors();
         HasUnsavedChanges = true;
     }
@@ -187,8 +188,6 @@ public partial class MainWindowViewModel : ViewModelBase
         _cutoffCountCalculator = new CutoffCountCalculator();
         _initialCutoffCalculator = new InitialCutoffCalculator();
         _cursorValidation = new CursorValidation();
-
-        _complianceRows = new ObservableCollection<ComplianceRowViewModel>();
 
         Log("MainWindowViewModel: Registering message handlers");
         // Subscribe to hover activation from delay service
@@ -296,17 +295,15 @@ public partial class MainWindowViewModel : ViewModelBase
             _cutoffCountCalculator,
             _initialCutoffCalculator);
 
+        ComplianceGrid = new ComplianceGridViewModel(ClassAssessment, GradingSession);
+
         SeedDefaultSelectionsIfEmpty();
 
-        // Helper owns: recompute curves/cutoffs against post-seed aggregates, rebuild
-        // _gradeAssigner, reset Cursors + ComplianceRows safely, and rewire the violin
-        // plot. T02 will reuse the same helper from ApplyScoreSelections when an
-        // aggregate-set change requires a cursor reset.
+        // SeedCursorsFromDefaults reseeds the session and rewires the
+        // violin plot. ApplyScoreSelections reuses it for an
+        // aggregate-set change.
         Log("MainWindowViewModel: Seeding cursors from default curve");
         SeedCursorsFromDefaults();
-
-        Log("MainWindowViewModel: Recalculating grade counts");
-        RecalculateGradeCounts();
 
         Log("MainWindowViewModel: Initializing dotplot");
         InitializeDotplot();
@@ -1076,120 +1073,37 @@ public partial class MainWindowViewModel : ViewModelBase
         }
     }
 
+    /// <summary>
+    /// Pushes the active session and the student-aggregate range onto
+    /// the violin VM. Compliance rows now flow through
+    /// <see cref="ComplianceGrid"/>'s own subscription, so the violin
+    /// reads them via that VM (not via MWVM).
+    /// </summary>
     private void WireViolinPlot()
     {
         if (ViolinPlotViewModel == null) return;
 
         ViolinPlotViewModel.GradingSession = GradingSession;
-        ViolinPlotViewModel.ComplianceRows = ComplianceRows;
+        ViolinPlotViewModel.ComplianceGrid = ComplianceGrid;
         ViolinPlotViewModel.MinScore = ClassAssessment.Assessments.Min(a => a.AggregateGrade);
         ViolinPlotViewModel.MaxScore = ClassAssessment.Assessments.Max(a => a.AggregateGrade);
     }
 
-    private void InitializeComplianceGrid()
-    {
-        var allGrades = new DefaultCurveGenerator().GetAllGrades();
-
-        foreach (var grade in allGrades)
-        {
-            var defaultEntry = ClassAssessment.DefaultCurve.FirstOrDefault(cc => cc.Grade.Equals(grade));
-            var currentEntry = ClassAssessment.Current.FirstOrDefault(cc => cc.Grade.Equals(grade));
-
-            int lowerTarget = defaultEntry?.LowerBound ?? 0;
-            int upperTarget = defaultEntry?.UpperBound ?? 0;
-            int currentCount = currentEntry?.Count ?? 0;
-            // All grades enabled at startup
-            bool isEnabled = true;
-
-            ComplianceRows.Add(new ComplianceRowViewModel(
-                grade,
-                lowerTarget,
-                upperTarget,
-                currentCount,
-                isEnabled,
-                OnComplianceCheckboxChanged
-            ));
-        }
-    }
-
     /// <summary>
-    /// Re-seeds the session from the default curve and refreshes the
-    /// compliance grid + violin wiring. Used by initial load
+    /// Re-seeds the session from the default curve and rewires the
+    /// violin plot. Used by initial load
     /// (<see cref="LoadFromExcelFile"/>, <see cref="LoadStateAsync"/>) and by
     /// the aggregate-set-changed branch of <see cref="ApplyScoreSelections"/>.
     /// The session itself owns the narrow-aggregate fallback (M002/S05/T03)
     /// inside <see cref="GradingSession.ReseedFromDefaults"/>, so the call
-    /// here always emits a valid state.
+    /// here always emits a valid state — and the
+    /// <see cref="ComplianceGridViewModel"/> picks up the new counts via
+    /// its own LastChange subscription.
     /// </summary>
     private void SeedCursorsFromDefaults()
     {
         GradingSession.ReseedFromDefaults();
-
-        // RecalculateGradeCounts has already fired via session.LastChange,
-        // but compliance rows are rebuilt below — refresh again so they
-        // pick up counts now that they exist.
-        ComplianceRows.Clear();
-        InitializeComplianceGrid();
-        SyncComplianceCountsFromSession();
-
         WireViolinPlot();
-    }
-
-    private void OnComplianceCheckboxChanged()
-    {
-        UpdateCursorsFromComplianceGrid();
-        UpdateDotplotPoints();
-    }
-
-    private void UpdateCursorsFromComplianceGrid()
-    {
-        // Compliance rows are still built for every grade (including the
-        // structural catch-all). The catch-all is not a session slot and
-        // is always considered enabled — its checkbox is inert until
-        // slice 4 (#10) extracts the ComplianceGridViewModel and limits
-        // the rows to draggable grades. Skip non-slot rows so we don't
-        // call session.EnableGrade/DisableGrade on the catch-all (which
-        // would throw).
-        var slotGrades = GradingSession.Slots.Select(s => s.Grade).ToHashSet();
-        foreach (var row in ComplianceRows)
-        {
-            if (!slotGrades.Contains(row.Grade)) continue;
-
-            var slot = GradingSession.Slots.First(s => s.Grade.Equals(row.Grade));
-            if (row.IsEnabled && !slot.IsEnabled)
-            {
-                GradingSession.EnableGrade(row.Grade, this);
-            }
-            else if (!row.IsEnabled && slot.IsEnabled)
-            {
-                GradingSession.DisableGrade(row.Grade, this);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Refreshes ClassAssessment cutoffs/counts and ComplianceRows.CurrentCount
-    /// from the session's current state. The session is the canonical source —
-    /// this method just propagates derived state into the legacy
-    /// ClassAssessment fields and the compliance UI.
-    /// </summary>
-    private void RecalculateGradeCounts()
-    {
-        var state = GradingSession.CurrentState;
-        ClassAssessment.CurrentCutoffs = state.Cutoffs;
-        ClassAssessment.Current = state.Counts;
-        _gradeAssigner = new GradeAssigner(state.Cutoffs);
-        SyncComplianceCountsFromSession();
-    }
-
-    private void SyncComplianceCountsFromSession()
-    {
-        var counts = GradingSession.CurrentState.Counts;
-        foreach (var row in ComplianceRows)
-        {
-            var currentEntry = counts.FirstOrDefault(cc => cc.Grade.Equals(row.Grade));
-            row.CurrentCount = currentEntry?.Count ?? 0;
-        }
     }
 
     [RelayCommand]
@@ -1289,6 +1203,8 @@ public partial class MainWindowViewModel : ViewModelBase
                 _cutoffCountCalculator,
                 _initialCutoffCalculator);
 
+            ComplianceGrid = new ComplianceGridViewModel(ClassAssessment, GradingSession);
+
             var (savedCutoffs, savedEnabledGrades) =
                 _stateService.ConvertToGradingState(state, GradingSession);
             GradingSession.LoadCutoffs(savedCutoffs, savedEnabledGrades);
@@ -1314,19 +1230,16 @@ public partial class MainWindowViewModel : ViewModelBase
             _currentSourceFile = state.SourceFile;
             CurrentSaveFilePath = filePath;
 
-            // SeedCursorsFromDefaults rebuilds compliance rows + violin
-            // wiring against the loaded session. The session was already
-            // hydrated above via GradingSession.LoadCutoffs, so saved
-            // cursor positions are preserved without an additional overlay.
+            // SeedCursorsFromDefaults rebuilds violin wiring against the
+            // loaded session. The session was already hydrated above via
+            // GradingSession.LoadCutoffs, so saved cursor positions are
+            // preserved without an additional overlay.
             Log("LoadStateAsync: Seeding cursors from default curve");
             SeedCursorsFromDefaults();
 
             // Re-apply the saved cutoffs after SeedCursorsFromDefaults
             // (which calls ReseedFromDefaults and overwrites them).
             GradingSession.LoadCutoffs(savedCutoffs, savedEnabledGrades);
-
-            Log("LoadStateAsync: Recalculating grade counts");
-            RecalculateGradeCounts();
 
             Log("LoadStateAsync: Initializing dotplot");
             InitializeDotplot();
@@ -1426,29 +1339,22 @@ public partial class MainWindowViewModel : ViewModelBase
         Log($"MainWindowViewModel: ApplyScoreSelections — first-student aggregate after={aggregateAfter} " +
             $"(changed={aggregateBefore != aggregateAfter})");
 
-        // Order matters: the per-student RecalculateAggregate loop above MUST run before
-        // SeedCursorsFromDefaults because the helper reads ClassAssessment.Assessments and
-        // computes new cutoffs against their freshly-updated AggregateGrade values.
-        // RecalculateGradeCounts (called below) MUST run AFTER the reset so it sees the
-        // freshly-seeded cursors, not the stale ones.
+        // The per-student RecalculateAggregate loop above MUST run
+        // before SeedCursorsFromDefaults so the session reseed sees
+        // the freshly-updated AggregateGrade values.
         //
-        // Edge case: when newAggregateKeys is empty, every student's AggregateGrade collapses
-        // to 0. Running the seed helper in that state would have InitialCutoffCalculator
-        // produce a mix of zero cutoffs (for grades whose target count is filled by zero-
-        // aggregate students) and stepping-down catch-all cutoffs (-12, -24, …) for grades
-        // past the last student, which then violates the "better grade ≥ worse grade"
-        // ordering invariant inside GradeAssigner and throws "Cutoffs are out of order"
-        // (per ApplyScoreSelections_WithEmptySelections_DoesNotCrash). The empty-aggregate
-        // configuration is itself a degenerate state — there is no meaningful cursor placement
-        // to be made — so we skip the reset and leave the existing cursors in place. Cursors
-        // remain visible so the user can re-add aggregate components and recover.
+        // Edge case: when newAggregateKeys is empty, every student's
+        // AggregateGrade collapses to 0 — the empty-aggregate
+        // configuration is degenerate (no meaningful cursor placement
+        // exists), so we skip the reset and leave the existing cursors
+        // in place. Cursors remain visible so the user can re-add
+        // aggregate components and recover.
         if (aggregateSetChanged && newAggregateKeys.Count > 0)
         {
             Log("MainWindowViewModel: ApplyScoreSelections — aggregate set changed, re-seeding cursors from default curve");
             SeedCursorsFromDefaults();
         }
 
-        RecalculateGradeCounts();
         UpdateDotplotPoints();
 
         // OxyPlot's PlotView does not auto-refresh when the model is mutated; InvalidatePlot
@@ -1486,8 +1392,7 @@ public partial class MainWindowViewModel : ViewModelBase
 
     private string GetGradeForStudent(StudentAssessment student)
     {
-        var grade = _gradeAssigner.AssignGrade(student.AggregateGrade);
-        return grade.DisplayName;
+        return GradingSession.AssignedGradeFor(student.Id).DisplayName;
     }
 
     /// <summary>

--- a/Dotsesses/UI/ViolinPlotControl.axaml.cs
+++ b/Dotsesses/UI/ViolinPlotControl.axaml.cs
@@ -205,7 +205,6 @@ public partial class ViolinPlotControl : UserControl
             }
 
             SubscribeToSession(vm.GradingSession);
-            SubscribeToComplianceRows(vm);
 
             vm.PropertyChanged += (s, args) =>
             {
@@ -215,9 +214,8 @@ public partial class ViolinPlotControl : UserControl
                     RenderRegionBands();
                     RenderCursorColumn();
                 }
-                else if (args.PropertyName == nameof(ViolinPlotViewModel.ComplianceRows))
+                else if (args.PropertyName == nameof(ViolinPlotViewModel.ComplianceGrid))
                 {
-                    SubscribeToComplianceRows(vm);
                     RenderCursorColumn();
                 }
             };
@@ -239,28 +237,14 @@ public partial class ViolinPlotControl : UserControl
 
     private void OnSessionPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
+        // Session emits LastChange whenever cursor positions or enabled
+        // grades shift. Re-render both surfaces so handles AND the
+        // count/deviation column track the change without an extra
+        // ComplianceRow subscription — the counts are read from
+        // ComplianceGrid.Rows during RenderCursorColumn.
         if (e.PropertyName != nameof(GradingSession.LastChange)) return;
         RenderRegionBands();
         RenderCursorColumn();
-    }
-
-    private void SubscribeToComplianceRows(ViolinPlotViewModel vm)
-    {
-        if (vm.ComplianceRows == null) return;
-
-        foreach (var row in vm.ComplianceRows)
-        {
-            row.PropertyChanged += OnComplianceRowPropertyChanged;
-        }
-    }
-
-    private void OnComplianceRowPropertyChanged(object? sender, PropertyChangedEventArgs e)
-    {
-        if (e.PropertyName == nameof(ComplianceRowViewModel.CurrentCount) ||
-            e.PropertyName == nameof(ComplianceRowViewModel.SignedDeviation))
-        {
-            RenderCursorColumn();   // Update Canvas cursor column with new counts
-        }
     }
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -930,7 +914,7 @@ public partial class ViolinPlotControl : UserControl
             var grade = enabledGrades[i];
 
             // Get compliance data for this grade
-            var compliance = vm.ComplianceRows?.FirstOrDefault(r => r.Grade.Equals(grade));
+            var compliance = vm.ComplianceGrid?.Rows.FirstOrDefault(r => r.Grade.Equals(grade));
             var currentCount = compliance?.CurrentCount ?? 0;
             var deviation = compliance?.SignedDeviation ?? 0;
 

--- a/Dotsesses/UI/ViolinPlotViewModel.cs
+++ b/Dotsesses/UI/ViolinPlotViewModel.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 using Avalonia;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -42,7 +41,7 @@ public partial class ViolinPlotViewModel : ViewModelBase
     private int? _hoveredStudentId;
 
     [ObservableProperty]
-    private ObservableCollection<ComplianceRowViewModel>? _complianceRows;
+    private ComplianceGridViewModel? _complianceGrid;
 
     [ObservableProperty]
     private int _minScore;

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -59,8 +59,11 @@ constructed `GradingSession` now provides the single seam from "no
 grading state" to "valid grading state" on every load (Excel and
 saved state), so the duplicate-append path no longer affects the
 canonical state. The legacy `_cursors` mirror collection was removed
-by issue #14; `InitializeComplianceGrid` remains until issue #10
-extracts `ComplianceGridViewModel`.
+by issue #14; `InitializeComplianceGrid` was deleted by issue #10
+(slice 4 of #6) — the new `ComplianceGridViewModel` builds rows
+once at construction and tracks state via its own
+`GradingSession.PropertyChanged` subscription, so there is no
+append-on-reload path to duplicate.
 
 ---
 
@@ -126,15 +129,15 @@ domain model says "user can disable a Grade" and the persistence
 layer round-trips that state, but a user actually trying it has
 nowhere to click.
 
-**Trigger:** Slice #5 of issue #6 (extract
-`ComplianceGridViewModel`) is the natural place to add the toggle
-control, since that's when Compliance rows become the canonical
-driver for `EnableGrade` / `DisableGrade`. If slice #5 lands without
-addressing this, open a dedicated issue.
+**Trigger:** The toggle wiring is now in place — issue #10 routed
+`ComplianceRowViewModel.IsEnabled` writes through `ComplianceGridViewModel`
+into `GradingSession.EnableGrade` / `DisableGrade`, so adding a
+checkbox in the AXAML row template is a single-binding change. Open a
+dedicated issue when prioritised.
 
-**Touches:** likely `Dotsesses/UI/MainWindow.axaml` (Compliance
-section) and `ComplianceRowViewModel` (already has `IsEnabled`
-shape).
+**Touches:** `Dotsesses/UI/MainWindow.axaml` (Compliance row template)
+— add a `CheckBox IsChecked="{Binding IsEnabled}"`. The catch-all row
+should not show the toggle (its state is structurally fixed).
 
 ---
 


### PR DESCRIPTION
Closes #10.

## Summary

- New `ComplianceGridViewModel` constructed from `(ClassAssessment, GradingSession)`. Rows built once from `DefaultCurve`; counts and enable state propagate on every `GradingSession.LastChange`.
- `ComplianceRowViewModel.IsEnabled` toggle on a slot row dispatches to `session.EnableGrade` / `DisableGrade`. The structural catch-all row (ADR-0011) is inert — its toggle no-ops and snaps back via the next sync.
- `MainWindowViewModel` loses `InitializeComplianceGrid`, `RecalculateGradeCounts`, `UpdateCursorsFromComplianceGrid`, `OnComplianceCheckboxChanged`, `SyncComplianceCountsFromSession`, and the `_gradeAssigner` field. `GradeAssigner` rebuilds fresh from `GradingSession.CurrentState.Cutoffs`; drill-down uses `GradingSession.AssignedGradeFor`.
- `ViolinPlotViewModel.ComplianceRows` → `ComplianceGrid`; violin's cursor column reads counts via `vm.ComplianceGrid.Rows`. Per-row subscriptions on the violin control collapse into a single `session.PropertyChanged` handler.
- AXAML rebound: `ItemsSource="{Binding ComplianceGrid.Rows}"`.

## Test plan

- [x] `dotnet test` — 183 pass, 0 fail (10 new `ComplianceGridViewModelTests`)
- [x] AC: no `InitializeComplianceGrid` / `RecalculateGradeCounts` / `ComplianceRows` references in MWVM
- [ ] Manual smoke test: load fixture, drag both surfaces, toggle Compliance, save+reopen — counts live, no regressions vs slice 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)