### PR TITLE
feat(workspaces): per-window DI scope foundation (slice 1 of #25)

### DIFF
--- a/Dotsesses.Tests/Services/WorkspaceFactoryTests.cs
+++ b/Dotsesses.Tests/Services/WorkspaceFactoryTests.cs
@@ -1,0 +1,84 @@
+namespace Dotsesses.Tests.Services;
+
+using CommunityToolkit.Mvvm.Messaging;
+using Dotsesses.Messages;
+using Dotsesses.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+public class WorkspaceFactoryTests
+{
+    private static WorkspaceFactory BuildFactoryWithMinimalRegistrations()
+    {
+        var services = new ServiceCollection();
+        services.AddScoped<IMessenger>(_ => new WeakReferenceMessenger());
+        services.AddScoped<HoverDelayService>();
+        services.AddSingleton<WorkspaceFactory>();
+        var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<WorkspaceFactory>();
+    }
+
+    [Fact]
+    public void TwoWorkspaces_HaveDistinctMessengers()
+    {
+        var factory = BuildFactoryWithMinimalRegistrations();
+        using var a = factory.Create();
+        using var b = factory.Create();
+
+        var m1 = a.Services.GetRequiredService<IMessenger>();
+        var m2 = b.Services.GetRequiredService<IMessenger>();
+
+        Assert.NotSame(m1, m2);
+    }
+
+    [Fact]
+    public void TwoWorkspaces_HaveDistinctHoverDelayServices()
+    {
+        var factory = BuildFactoryWithMinimalRegistrations();
+        using var a = factory.Create();
+        using var b = factory.Create();
+
+        var h1 = a.Services.GetRequiredService<HoverDelayService>();
+        var h2 = b.Services.GetRequiredService<HoverDelayService>();
+
+        Assert.NotSame(h1, h2);
+    }
+
+    [Fact]
+    public void MessageSentInOneWorkspace_DoesNotReachAnother()
+    {
+        var factory = BuildFactoryWithMinimalRegistrations();
+        using var a = factory.Create();
+        using var b = factory.Create();
+
+        var m1 = a.Services.GetRequiredService<IMessenger>();
+        var m2 = b.Services.GetRequiredService<IMessenger>();
+
+        var receiver = new object();
+        bool received = false;
+        m2.Register<StudentEditedMessage>(receiver, (_, _) => received = true);
+
+        m1.Send(new StudentEditedMessage(42));
+
+        Assert.False(received);
+        GC.KeepAlive(receiver);
+    }
+
+    [Fact]
+    public void DisposingOneWorkspace_DoesNotAffectAnother()
+    {
+        var factory = BuildFactoryWithMinimalRegistrations();
+        var a = factory.Create();
+        using var b = factory.Create();
+
+        var m2 = b.Services.GetRequiredService<IMessenger>();
+        a.Dispose();
+
+        var receiver = new object();
+        bool received = false;
+        m2.Register<StudentEditedMessage>(receiver, (_, _) => received = true);
+        m2.Send(new StudentEditedMessage(42));
+
+        Assert.True(received);
+        GC.KeepAlive(receiver);
+    }
+}

--- a/Dotsesses.Tests/ViewModels/StudentCardViewModelTests.cs
+++ b/Dotsesses.Tests/ViewModels/StudentCardViewModelTests.cs
@@ -1,6 +1,7 @@
 namespace Dotsesses.Tests.ViewModels;
 
 using System.ComponentModel;
+using CommunityToolkit.Mvvm.Messaging;
 using Dotsesses.Models;
 using Dotsesses.UI;
 
@@ -34,7 +35,7 @@ public class StudentCardViewModelTests
         var colors = new Dictionary<string, string> { ["Q1"] = "#000", ["Q2"] = "#111", ["Total"] = "#222" };
 
         // Act — construct with no displayScores arg (back-compat path).
-        using var card = new StudentCardViewModel(assessment, "B", colors);
+        using var card = new StudentCardViewModel(assessment, "B", colors, new WeakReferenceMessenger());
 
         // Assert — DisplayScores is the full Assessment.Scores list.
         Assert.Equal(assessment.Scores.Count, card.DisplayScores.Count);
@@ -50,7 +51,7 @@ public class StudentCardViewModelTests
         var filtered = assessment.Scores.Take(2).ToList();
 
         // Act
-        using var card = new StudentCardViewModel(assessment, "B", colors, clearAction: null, displayScores: filtered);
+        using var card = new StudentCardViewModel(assessment, "B", colors, new WeakReferenceMessenger(), clearAction: null, displayScores: filtered);
 
         // Assert — exactly 2 items, in order, matching the input.
         Assert.Equal(2, card.DisplayScores.Count);
@@ -74,7 +75,7 @@ public class StudentCardViewModelTests
         Assert.False(filtered.Contains(excluded), "Sanity: filter must exclude the third score.");
 
         // Act
-        using var card = new StudentCardViewModel(assessment, "B", colors, clearAction: null, displayScores: filtered);
+        using var card = new StudentCardViewModel(assessment, "B", colors, new WeakReferenceMessenger(), clearAction: null, displayScores: filtered);
 
         // Assert — every score in Assessment.Scores (including the excluded one) has at
         // least one PropertyChanged subscriber attached.

--- a/Dotsesses/App.axaml.cs
+++ b/Dotsesses/App.axaml.cs
@@ -61,7 +61,8 @@ public partial class App : Application
                 ConfigureServices(services);
                 Services = services.BuildServiceProvider();
 
-                var viewModel = Services.GetRequiredService<MainWindowViewModel>();
+                var snapshotWorkspace = Services.GetRequiredService<WorkspaceFactory>().Create();
+                var viewModel = snapshotWorkspace.Services.GetRequiredService<MainWindowViewModel>();
 
                 // For snapshot mode, require source file path via StartupConfig
                 if (string.IsNullOrEmpty(StartupConfig.SourceFilePath))
@@ -213,7 +214,11 @@ public partial class App : Application
                         await Dispatcher.UIThread.InvokeAsync(async () =>
                         {
                             Log("Startup: Instantiating MainWindow");
-                            var viewModel = Services.GetRequiredService<MainWindowViewModel>();
+                            // Build a per-window DI scope via WorkspaceFactory (ADR-0012).
+                            // The scope lives as long as the window — held on _initialWorkspace
+                            // so a future slice can dispose it on close.
+                            _initialWorkspace = Services.GetRequiredService<WorkspaceFactory>().Create();
+                            var viewModel = _initialWorkspace.Services.GetRequiredService<MainWindowViewModel>();
 
                             // Load based on file extension
                             var extension = Path.GetExtension(sourceFilePath).ToLowerInvariant();
@@ -320,18 +325,27 @@ public partial class App : Application
         progressCallback?.Invoke("Registering application services...");
         Log("ConfigureServices: Registering application services");
 
-        // Register messenger
-        services.AddSingleton<IMessenger>(WeakReferenceMessenger.Default);
+        // Per-workspace messenger: one instance per scope, never the static
+        // .Default. See ADR-0012 for why scoping is required for multi-window.
+        services.AddScoped<IMessenger>(_ => new WeakReferenceMessenger());
 
-        // Register services
+        // Stateless Python-interop renderers — shared across all workspaces.
         services.AddSingleton<ViolinPlotService>();
         services.AddSingleton<CorrelationPlotService>();
-        services.AddSingleton<HoverDelayService>();
 
-        // Register ViewModels
-        services.AddTransient<MainWindowViewModel>();
-        services.AddTransient<ViolinPlotViewModel>();
-        services.AddTransient<CorrelationPlotViewModel>();
+        // Scoped: one per workspace.
+        services.AddScoped<HoverDelayService>();
+        services.AddScoped<StateService>();
+
+        // Workspace factory — wraps IServiceScopeFactory to produce per-window
+        // scopes. App-singleton so each Open Another call resolves the same
+        // factory instance.
+        services.AddSingleton<WorkspaceFactory>();
+
+        // Per-workspace ViewModels.
+        services.AddScoped<MainWindowViewModel>();
+        services.AddScoped<ViolinPlotViewModel>();
+        services.AddScoped<CorrelationPlotViewModel>();
 
         Log("ConfigureServices: Completed");
     }
@@ -350,6 +364,7 @@ public partial class App : Application
     }
 
     private MainWindow? _mainWindow;
+    private Workspace? _initialWorkspace;
 
     private async void OnSaveClicked(object? sender, EventArgs e)
     {

--- a/Dotsesses/Services/ImageCopyService.cs
+++ b/Dotsesses/Services/ImageCopyService.cs
@@ -23,13 +23,14 @@ public static class ImageCopyService
     /// The caller is responsible for disposing the returned stream.
     /// </summary>
     /// <param name="control">The control to render</param>
+    /// <param name="messenger">The scoped messenger of the invoking window — used to broadcast theme switches to that window's controls only. See ADR-0012.</param>
     /// <param name="restoreTheme">If true, restores DarkMode after rendering. Set to false when batching multiple renders.</param>
     /// <returns>A MemoryStream containing the PNG image data</returns>
-    public static async Task<MemoryStream> RenderControlToPngStreamAsync(Control control, bool restoreTheme = true)
+    public static async Task<MemoryStream> RenderControlToPngStreamAsync(Control control, IMessenger messenger, bool restoreTheme = true)
     {
         // Switch to LightMode and wait for re-render
         var renderComplete = new TaskCompletionSource<bool>();
-        WeakReferenceMessenger.Default.Send(new RenderWithThemeMessage(
+        messenger.Send(new RenderWithThemeMessage(
             ThemeName.LightMode,
             () => renderComplete.TrySetResult(true)));
 
@@ -60,7 +61,7 @@ public static class ImageCopyService
         {
             if (restoreTheme)
             {
-                WeakReferenceMessenger.Default.Send(new RenderWithThemeMessage(ThemeName.DarkMode));
+                messenger.Send(new RenderWithThemeMessage(ThemeName.DarkMode));
             }
             throw new InvalidOperationException("Control has zero size and cannot be rendered");
         }
@@ -89,7 +90,7 @@ public static class ImageCopyService
         // Restore theme if requested
         if (restoreTheme)
         {
-            WeakReferenceMessenger.Default.Send(new RenderWithThemeMessage(ThemeName.DarkMode));
+            messenger.Send(new RenderWithThemeMessage(ThemeName.DarkMode));
         }
 
         return stream;
@@ -99,17 +100,17 @@ public static class ImageCopyService
     /// Restores the application to DarkMode theme.
     /// Call this after batching multiple renders with restoreTheme=false.
     /// </summary>
-    public static void RestoreDarkMode()
+    public static void RestoreDarkMode(IMessenger messenger)
     {
-        WeakReferenceMessenger.Default.Send(new RenderWithThemeMessage(ThemeName.DarkMode));
+        messenger.Send(new RenderWithThemeMessage(ThemeName.DarkMode));
     }
 
     /// <summary>
     /// Renders a control to bitmap in LightMode theme and copies to clipboard.
     /// </summary>
-    public static async Task CopyControlToClipboardAsync(Control control, IClipboard clipboard)
+    public static async Task CopyControlToClipboardAsync(Control control, IClipboard clipboard, IMessenger messenger)
     {
-        using var stream = await RenderControlToPngStreamAsync(control);
+        using var stream = await RenderControlToPngStreamAsync(control, messenger);
 
         // Save to temp file and copy to clipboard
         var tempPath = Path.Combine(Path.GetTempPath(), $"dotsesses_copy_{DateTime.Now:HHmmss}.png");

--- a/Dotsesses/Services/PowerPointExportService.cs
+++ b/Dotsesses/Services/PowerPointExportService.cs
@@ -4,6 +4,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media.Imaging;
 using Avalonia.Threading;
+using CommunityToolkit.Mvvm.Messaging;
 using Dotsesses.UI;
 using ShapeCrawler;
 
@@ -36,6 +37,7 @@ public class PowerPointExportService
         Control correlationPlotControl,
         PlotTabContainerViewModel tabViewModel,
         IEnumerable<ComplianceRowViewModel> complianceRows,
+        IMessenger messenger,
         string className = "Grade Analysis")
     {
         // Create presentation with first slide
@@ -45,7 +47,7 @@ public class PowerPointExportService
         {
             // Slide 1: DotPlot (don't restore theme yet - we'll batch renders)
             ClearPlaceholders(pres, 1);
-            await AddPlotSlideAsync(pres, 1, $"{className} - Score Distribution", dotPlotControl, restoreTheme: false);
+            await AddPlotSlideAsync(pres, 1, $"{className} - Score Distribution", dotPlotControl, messenger, restoreTheme: false);
 
             // Slide 2: ViolinPlot - ensure it's visible first
             await Dispatcher.UIThread.InvokeAsync(() =>
@@ -56,7 +58,7 @@ public class PowerPointExportService
 
             pres.Slides.Add(1);
             ClearPlaceholders(pres, 2);
-            await AddPlotSlideAsync(pres, 2, $"{className} - Component Analysis", violinPlotControl, restoreTheme: false);
+            await AddPlotSlideAsync(pres, 2, $"{className} - Component Analysis", violinPlotControl, messenger, restoreTheme: false);
 
             // Slide 3: CorrelationPlot - switch to correlation tab first
             await Dispatcher.UIThread.InvokeAsync(() =>
@@ -68,7 +70,7 @@ public class PowerPointExportService
 
             pres.Slides.Add(1);
             ClearPlaceholders(pres, 3);
-            await AddPlotSlideAsync(pres, 3, $"{className} - Score Correlations", correlationPlotControl, restoreTheme: false);
+            await AddPlotSlideAsync(pres, 3, $"{className} - Score Correlations", correlationPlotControl, messenger, restoreTheme: false);
 
             // Slide 4: Grade Table (no rendering needed)
             pres.Slides.Add(1);
@@ -91,7 +93,7 @@ public class PowerPointExportService
             {
                 tabViewModel.SelectViolinCommand.Execute(null);
             });
-            ImageCopyService.RestoreDarkMode();
+            ImageCopyService.RestoreDarkMode(messenger);
         }
     }
 
@@ -116,6 +118,7 @@ public class PowerPointExportService
         int slideNumber,
         string title,
         Control plotControl,
+        IMessenger messenger,
         bool restoreTheme = true)
     {
         var shapes = pres.Slide(slideNumber).Shapes;
@@ -124,7 +127,7 @@ public class PowerPointExportService
         AddTitle(pres, slideNumber, title);
 
         // Render plot to PNG stream
-        using var imageStream = await ImageCopyService.RenderControlToPngStreamAsync(plotControl, restoreTheme);
+        using var imageStream = await ImageCopyService.RenderControlToPngStreamAsync(plotControl, messenger, restoreTheme);
 
         // Get image dimensions to calculate aspect ratio
         imageStream.Position = 0;

--- a/Dotsesses/Services/Workspace.cs
+++ b/Dotsesses/Services/Workspace.cs
@@ -1,0 +1,32 @@
+namespace Dotsesses.Services;
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// One loaded analysis's DI scope. Owns the scope's <see cref="IServiceProvider"/>
+/// and disposes it when the owning window closes. Exposed services (IMessenger,
+/// HoverDelayService, the per-analysis ViewModels) are scoped, so each Workspace
+/// gets its own instances — messages and hover state cannot cross between
+/// workspaces. See ADR-0012.
+/// </summary>
+public sealed class Workspace : IDisposable
+{
+    private readonly IServiceScope _scope;
+    private bool _disposed;
+
+    public IServiceProvider Services => _scope.ServiceProvider;
+
+    public Workspace(IServiceScope scope)
+    {
+        ArgumentNullException.ThrowIfNull(scope);
+        _scope = scope;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _scope.Dispose();
+    }
+}

--- a/Dotsesses/Services/WorkspaceFactory.cs
+++ b/Dotsesses/Services/WorkspaceFactory.cs
@@ -1,0 +1,22 @@
+namespace Dotsesses.Services;
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Produces a fresh <see cref="Workspace"/> on demand, each backed by its
+/// own DI scope. App-singleton — the factory itself outlives any individual
+/// workspace. See ADR-0012.
+/// </summary>
+public sealed class WorkspaceFactory
+{
+    private readonly IServiceScopeFactory _scopes;
+
+    public WorkspaceFactory(IServiceScopeFactory scopes)
+    {
+        ArgumentNullException.ThrowIfNull(scopes);
+        _scopes = scopes;
+    }
+
+    public Workspace Create() => new(_scopes.CreateScope());
+}

--- a/Dotsesses/UI/CorrelationPlotControl.axaml.cs
+++ b/Dotsesses/UI/CorrelationPlotControl.axaml.cs
@@ -40,10 +40,11 @@ public partial class CorrelationPlotControl : UserControl
         // Add button handlers
         CopyCorrelationPlotButton.Click += OnCopyClick;
         DiagonalToggleButton.Click += OnDiagonalToggleClick;
-
-        // Subscribe to theme change messages
-        WeakReferenceMessenger.Default.Register<RenderWithThemeMessage>(this, OnRenderWithThemeMessage);
+        // Theme-change registration moves to OnDataContextChanged — it needs
+        // the scoped IMessenger from the VM (per ADR-0012).
     }
+
+    private bool _messengerRegistered;
 
     private void OnRenderWithThemeMessage(object recipient, RenderWithThemeMessage message)
     {
@@ -144,6 +145,12 @@ public partial class CorrelationPlotControl : UserControl
     {
         if (DataContext is CorrelationPlotViewModel vm)
         {
+            if (!_messengerRegistered)
+            {
+                _messengerRegistered = true;
+                vm.Messenger.Register<RenderWithThemeMessage>(this, OnRenderWithThemeMessage);
+            }
+
             vm.PropertyChanged += OnViewModelPropertyChanged;
 
             if (!string.IsNullOrEmpty(vm.SvgContent))
@@ -358,7 +365,7 @@ public partial class CorrelationPlotControl : UserControl
             // Clicked on empty space - clear hover
             if (position.Properties.IsLeftButtonPressed)
             {
-                WeakReferenceMessenger.Default.Send(new StudentHoverMessage(null, "correlation"));
+                (DataContext as CorrelationPlotViewModel)?.Messenger.Send(new StudentHoverMessage(null, "correlation"));
                 e.Handled = true;
             }
         }
@@ -368,6 +375,8 @@ public partial class CorrelationPlotControl : UserControl
     {
         var position = e.GetCurrentPoint(PointsOverlay);
         var clickedElement = PointsOverlay.InputHitTest(position.Position);
+        var messenger = (DataContext as CorrelationPlotViewModel)?.Messenger;
+        if (messenger == null) return;
 
         int? studentId = null;
         if (clickedElement is Control control && control.Tag is ValueTuple<int, int> tag)
@@ -380,7 +389,7 @@ public partial class CorrelationPlotControl : UserControl
             // Handle right-click - open comment editor
             if (position.Properties.IsRightButtonPressed)
             {
-                WeakReferenceMessenger.Default.Send(new EditStudentMessage(studentId.Value));
+                messenger.Send(new EditStudentMessage(studentId.Value));
                 e.Handled = true;
                 return;
             }
@@ -393,7 +402,7 @@ public partial class CorrelationPlotControl : UserControl
 
                 if (_lastClickedStudentId == studentId && timeSinceLastClick < DoubleClickThresholdMs)
                 {
-                    WeakReferenceMessenger.Default.Send(new EditStudentMessage(studentId.Value));
+                    messenger.Send(new EditStudentMessage(studentId.Value));
                     _lastClickedStudentId = null;
                     e.Handled = true;
                     return;
@@ -409,7 +418,7 @@ public partial class CorrelationPlotControl : UserControl
             // Clicked on empty space - clear hover
             if (position.Properties.IsLeftButtonPressed)
             {
-                WeakReferenceMessenger.Default.Send(new StudentHoverMessage(null, "correlation"));
+                messenger.Send(new StudentHoverMessage(null, "correlation"));
                 e.Handled = true;
             }
         }
@@ -428,7 +437,8 @@ public partial class CorrelationPlotControl : UserControl
         var topLevel = TopLevel.GetTopLevel(this);
         var clipboard = topLevel?.Clipboard;
         if (clipboard == null) return;
+        if (DataContext is not CorrelationPlotViewModel vm) return;
 
-        await ImageCopyService.CopyControlToClipboardAsync(this, clipboard);
+        await ImageCopyService.CopyControlToClipboardAsync(this, clipboard, vm.Messenger);
     }
 }

--- a/Dotsesses/UI/CorrelationPlotViewModel.cs
+++ b/Dotsesses/UI/CorrelationPlotViewModel.cs
@@ -40,6 +40,13 @@ public partial class CorrelationPlotViewModel : ViewModelBase
     [ObservableProperty]
     private bool _showCorrelationCoefficients = true;
 
+    /// <summary>
+    /// The scoped messenger for this VM's workspace. Exposed for the
+    /// View code-behind (CorrelationPlotControl) to register/send within
+    /// the same window's scope. See ADR-0012.
+    /// </summary>
+    public IMessenger Messenger => _messenger;
+
     public CorrelationPlotViewModel(
         CorrelationPlotService correlationService,
         IMessenger messenger,

--- a/Dotsesses/UI/MainWindow.axaml.cs
+++ b/Dotsesses/UI/MainWindow.axaml.cs
@@ -34,6 +34,7 @@ namespace Dotsesses.UI;
 public partial class MainWindow : Window
 {
     private HoverDelayService? _hoverDelayService;
+    private bool _messengerRegistered;
 
     /// <summary>
     /// Single-instance gate for the modeless Settings window. Set on <see cref="OpenSettings"/>
@@ -51,48 +52,8 @@ public partial class MainWindow : Window
         Closing += OnWindowClosing;
         PointerMoved += OnGlobalPointerMoved;
         KeyDown += OnGlobalKeyDown;
-
-        // Subscribe to edit student messages
-        WeakReferenceMessenger.Default.Register<EditStudentMessage>(this, async (r, m) =>
-        {
-            await HandleEditStudentRequest(m);
-        });
-
-        // Subscribe to theme change messages for DotPlot
-        WeakReferenceMessenger.Default.Register<RenderWithThemeMessage>(this, OnRenderWithThemeMessage);
-
-        // Surface background plot-init failures as a dialog instead of
-        // letting an unhandled task exception abort the process.
-        WeakReferenceMessenger.Default.Register<PlotInitErrorMessage>(this, async (r, m) =>
-        {
-            await Dispatcher.UIThread.InvokeAsync(async () =>
-            {
-                var errorBox = MessageBoxManager.GetMessageBoxStandard(
-                    $"{m.PlotName} failed",
-                    $"Could not generate the {m.PlotName.ToLowerInvariant()} for this file:\n\n{m.ErrorMessage}",
-                    ButtonEnum.Ok,
-                    MsBoxIcon.Warning);
-                await errorBox.ShowWindowDialogAsync(this);
-            });
-        });
-
-        // Surface non-fatal load warnings (duplicate columns, sparse /
-        // constant series, skipped rows, synthesized Total, etc.) as a
-        // single combined dialog after the file finishes loading.
-        WeakReferenceMessenger.Default.Register<LoadWarningsMessage>(this, async (r, m) =>
-        {
-            await Dispatcher.UIThread.InvokeAsync(async () =>
-            {
-                var body = string.Join("\n\n",
-                    m.Warnings.Select(w => $"• {w.Message}"));
-                var box = MessageBoxManager.GetMessageBoxStandard(
-                    $"Loaded with {m.Warnings.Count} warning{(m.Warnings.Count == 1 ? "" : "s")}",
-                    body,
-                    ButtonEnum.Ok,
-                    MsBoxIcon.Info);
-                await box.ShowWindowDialogAsync(this);
-            });
-        });
+        // Message registrations move to OnDataContextChanged — they need
+        // the scoped IMessenger from the VM (per ADR-0012).
     }
 
     // Current theme for DotPlot
@@ -242,9 +203,10 @@ public partial class MainWindow : Window
     {
         var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
         if (clipboard == null) return;
+        if (DataContext is not MainWindowViewModel vm) return;
 
         // Copy the DotPlotBorder (includes the border, which becomes visible in light mode)
-        await ImageCopyService.CopyControlToClipboardAsync(DotPlotBorder, clipboard);
+        await ImageCopyService.CopyControlToClipboardAsync(DotPlotBorder, clipboard, vm.Messenger);
     }
 
     private async void OnExportPptxButtonClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
@@ -395,6 +357,7 @@ public partial class MainWindow : Window
                 correlationPlotControl,
                 vm.PlotTabContainerViewModel,
                 vm.ComplianceGrid?.Rows ?? Enumerable.Empty<Dotsesses.UI.ComplianceRowViewModel>(),
+                vm.Messenger,
                 className);
 
             // Show success message with option to open
@@ -584,10 +547,54 @@ public partial class MainWindow : Window
 
     private void OnDataContextChanged(object? sender, EventArgs e)
     {
-        if (DataContext is MainWindowViewModel vm)
+        if (DataContext is not MainWindowViewModel vm) return;
+
+        vm.PropertyChanged += OnViewModelPropertyChanged;
+
+        if (_messengerRegistered) return;
+        _messengerRegistered = true;
+
+        var messenger = vm.Messenger;
+
+        messenger.Register<EditStudentMessage>(this, async (r, m) =>
         {
-            vm.PropertyChanged += OnViewModelPropertyChanged;
-        }
+            await HandleEditStudentRequest(m);
+        });
+
+        messenger.Register<RenderWithThemeMessage>(this, OnRenderWithThemeMessage);
+
+        // Surface background plot-init failures as a dialog instead of
+        // letting an unhandled task exception abort the process.
+        messenger.Register<PlotInitErrorMessage>(this, async (r, m) =>
+        {
+            await Dispatcher.UIThread.InvokeAsync(async () =>
+            {
+                var errorBox = MessageBoxManager.GetMessageBoxStandard(
+                    $"{m.PlotName} failed",
+                    $"Could not generate the {m.PlotName.ToLowerInvariant()} for this file:\n\n{m.ErrorMessage}",
+                    ButtonEnum.Ok,
+                    MsBoxIcon.Warning);
+                await errorBox.ShowWindowDialogAsync(this);
+            });
+        });
+
+        // Surface non-fatal load warnings (duplicate columns, sparse /
+        // constant series, skipped rows, synthesized Total, etc.) as a
+        // single combined dialog after the file finishes loading.
+        messenger.Register<LoadWarningsMessage>(this, async (r, m) =>
+        {
+            await Dispatcher.UIThread.InvokeAsync(async () =>
+            {
+                var body = string.Join("\n\n",
+                    m.Warnings.Select(w => $"• {w.Message}"));
+                var box = MessageBoxManager.GetMessageBoxStandard(
+                    $"Loaded with {m.Warnings.Count} warning{(m.Warnings.Count == 1 ? "" : "s")}",
+                    body,
+                    ButtonEnum.Ok,
+                    MsBoxIcon.Info);
+                await box.ShowWindowDialogAsync(this);
+            });
+        });
     }
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -821,7 +828,10 @@ public partial class MainWindow : Window
             totalScore.Comment = newComment;
 
             // Broadcast that the student was edited
-            WeakReferenceMessenger.Default.Send(new StudentEditedMessage(message.StudentId));
+            if (DataContext is MainWindowViewModel mwvm)
+            {
+                mwvm.Messenger.Send(new StudentEditedMessage(message.StudentId));
+            }
         }
     }
 

--- a/Dotsesses/UI/MainWindowViewModel.cs
+++ b/Dotsesses/UI/MainWindowViewModel.cs
@@ -37,7 +37,7 @@ public partial class MainWindowViewModel : ViewModelBase
     private readonly CursorValidation _cursorValidation = null!;
     private readonly IMessenger _messenger = null!;
     private readonly HoverDelayService _hoverDelayService = null!;
-    private readonly StateService _stateService = new();
+    private readonly StateService _stateService = null!;
 
     /// <summary>
     /// Gets a fresh GradeAssigner built from the session's current
@@ -125,6 +125,14 @@ public partial class MainWindowViewModel : ViewModelBase
     public StateService StateService => _stateService;
 
     /// <summary>
+    /// The scoped messenger that belongs to this VM's workspace. View
+    /// code-behind reaches it through <c>DataContext</c> to register
+    /// for messages and to broadcast within the same window's scope.
+    /// See ADR-0012.
+    /// </summary>
+    public IMessenger Messenger => _messenger;
+
+    /// <summary>
     /// Re-renders dotplot annotations from the session's current state.
     /// Invoked whenever the session emits a LastChange notification
     /// (drag commit, enable/disable, reseed, load). Compliance counts
@@ -172,7 +180,8 @@ public partial class MainWindowViewModel : ViewModelBase
         IMessenger messenger,
         ViolinPlotViewModel violinPlotViewModel,
         CorrelationPlotViewModel correlationPlotViewModel,
-        HoverDelayService hoverDelayService)
+        HoverDelayService hoverDelayService,
+        StateService stateService)
     {
         Log("MainWindowViewModel: Constructor started");
 
@@ -180,6 +189,7 @@ public partial class MainWindowViewModel : ViewModelBase
         _violinPlotViewModel = violinPlotViewModel;
         _correlationPlotViewModel = correlationPlotViewModel;
         _hoverDelayService = hoverDelayService;
+        _stateService = stateService;
 
         // Create the tab container ViewModel
         _plotTabContainerViewModel = new PlotTabContainerViewModel(violinPlotViewModel, correlationPlotViewModel);
@@ -238,10 +248,11 @@ public partial class MainWindowViewModel : ViewModelBase
     public static MainWindowViewModel CreateForTesting()
     {
         return new MainWindowViewModel(
-            WeakReferenceMessenger.Default,
+            new WeakReferenceMessenger(),
             null!,
             null!,
-            new HoverDelayService());
+            new HoverDelayService(),
+            new StateService());
     }
 
     /// <summary>
@@ -1478,7 +1489,7 @@ public partial class MainWindowViewModel : ViewModelBase
             if (student != null)
             {
                 var grade = GetGradeForStudent(student);
-                HoveredStudent = new StudentCardViewModel(student, grade, ClassAssessment.SeriesColorMap, () => _hoverDelayService.ClearHover(), BuildDisplayScores(student));
+                HoveredStudent = new StudentCardViewModel(student, grade, ClassAssessment.SeriesColorMap, _messenger, () => _hoverDelayService.ClearHover(), BuildDisplayScores(student));
             }
             else
             {

--- a/Dotsesses/UI/StudentCardViewModel.cs
+++ b/Dotsesses/UI/StudentCardViewModel.cs
@@ -17,6 +17,7 @@ using Dotsesses.Models;
 public partial class StudentCardViewModel : ObservableObject, IDisposable
 {
     private readonly Action? _clearAction;
+    private readonly IMessenger _messenger;
     private CancellationTokenSource? _debounce;
     private bool _disposed;
 
@@ -41,11 +42,12 @@ public partial class StudentCardViewModel : ObservableObject, IDisposable
     /// </summary>
     public IReadOnlyList<Score> DisplayScores { get; }
 
-    public StudentCardViewModel(StudentAssessment assessment, string assignedGrade, Dictionary<string, string> seriesColorMap, Action? clearAction = null, IReadOnlyList<Score>? displayScores = null)
+    public StudentCardViewModel(StudentAssessment assessment, string assignedGrade, Dictionary<string, string> seriesColorMap, IMessenger messenger, Action? clearAction = null, IReadOnlyList<Score>? displayScores = null)
     {
         _assessment = assessment;
         _assignedGrade = assignedGrade;
         SeriesColorMap = seriesColorMap;
+        _messenger = messenger;
         _clearAction = clearAction;
         DisplayScores = displayScores ?? assessment.Scores;
 
@@ -74,7 +76,7 @@ public partial class StudentCardViewModel : ObservableObject, IDisposable
                 // Must send message on UI thread
                 Avalonia.Threading.Dispatcher.UIThread.Post(() =>
                 {
-                    WeakReferenceMessenger.Default.Send(new StudentEditedMessage(Assessment.Id));
+                    _messenger.Send(new StudentEditedMessage(Assessment.Id));
                 });
             }
         }, token);

--- a/Dotsesses/UI/ViolinPlotControl.axaml.cs
+++ b/Dotsesses/UI/ViolinPlotControl.axaml.cs
@@ -52,10 +52,11 @@ public partial class ViolinPlotControl : UserControl
 
         // Render cursor column when its layout is updated (bounds become available)
         CursorColumnCanvas.LayoutUpdated += OnCursorColumnLayoutUpdated;
-
-        // Subscribe to theme change messages
-        WeakReferenceMessenger.Default.Register<RenderWithThemeMessage>(this, OnRenderWithThemeMessage);
+        // Theme-change registration moves to OnDataContextChanged — it needs
+        // the scoped IMessenger from the VM (per ADR-0012).
     }
+
+    private bool _messengerRegistered;
 
     private void OnRenderWithThemeMessage(object recipient, RenderWithThemeMessage message)
     {
@@ -196,6 +197,12 @@ public partial class ViolinPlotControl : UserControl
     {
         if (DataContext is ViolinPlotViewModel vm)
         {
+            if (!_messengerRegistered)
+            {
+                _messengerRegistered = true;
+                vm.Messenger.Register<RenderWithThemeMessage>(this, OnRenderWithThemeMessage);
+            }
+
             vm.PropertyChanged += OnViewModelPropertyChanged;
 
             // Check if SVG content already exists (set before this control was created)
@@ -693,12 +700,15 @@ public partial class ViolinPlotControl : UserControl
             studentId = tag.Item2; // Second item is the student ID
         }
 
+        var messenger = (DataContext as ViolinPlotViewModel)?.Messenger;
+        if (messenger == null) return;
+
         if (studentId.HasValue)
         {
             // Handle right-click - open comment editor
             if (position.Properties.IsRightButtonPressed)
             {
-                WeakReferenceMessenger.Default.Send(new EditStudentMessage(studentId.Value));
+                messenger.Send(new EditStudentMessage(studentId.Value));
                 e.Handled = true;
                 return;
             }
@@ -712,7 +722,7 @@ public partial class ViolinPlotControl : UserControl
                 if (_lastClickedStudentId == studentId && timeSinceLastClick < DoubleClickThresholdMs)
                 {
                     // Double-click detected - open comment editor
-                    WeakReferenceMessenger.Default.Send(new EditStudentMessage(studentId.Value));
+                    messenger.Send(new EditStudentMessage(studentId.Value));
                     _lastClickedStudentId = null; // Reset to prevent triple-click
                     e.Handled = true;
                     return;
@@ -729,7 +739,7 @@ public partial class ViolinPlotControl : UserControl
             // Clicked on empty space - clear hover
             if (position.Properties.IsLeftButtonPressed)
             {
-                WeakReferenceMessenger.Default.Send(new StudentHoverMessage(null, "violin"));
+                messenger.Send(new StudentHoverMessage(null, "violin"));
                 e.Handled = true;
             }
         }
@@ -833,7 +843,7 @@ public partial class ViolinPlotControl : UserControl
         else
         {
             // Clicked on empty space - clear hover
-            WeakReferenceMessenger.Default.Send(new StudentHoverMessage(null, "violin"));
+            (DataContext as ViolinPlotViewModel)?.Messenger.Send(new StudentHoverMessage(null, "violin"));
             e.Handled = true;
         }
     }
@@ -1133,8 +1143,9 @@ public partial class ViolinPlotControl : UserControl
         var topLevel = TopLevel.GetTopLevel(this);
         var clipboard = topLevel?.Clipboard;
         if (clipboard == null) return;
+        if (DataContext is not ViolinPlotViewModel vm) return;
 
         // Copy the entire control (includes all overlays)
-        await ImageCopyService.CopyControlToClipboardAsync(this, clipboard);
+        await ImageCopyService.CopyControlToClipboardAsync(this, clipboard, vm.Messenger);
     }
 }

--- a/Dotsesses/UI/ViolinPlotViewModel.cs
+++ b/Dotsesses/UI/ViolinPlotViewModel.cs
@@ -57,6 +57,12 @@ public partial class ViolinPlotViewModel : ViewModelBase
     [ObservableProperty]
     private GradingSession? _gradingSession;
 
+    /// <summary>
+    /// The scoped messenger for this VM's workspace. Exposed for the
+    /// View code-behind (ViolinPlotControl) to register/send within the
+    /// same window's scope. See ADR-0012.
+    /// </summary>
+    public IMessenger Messenger => _messenger;
 
     public ViolinPlotViewModel(ViolinPlotService violinService, IMessenger messenger, HoverDelayService hoverDelayService)
     {

--- a/docs/adr/0012-one-window-per-loaded-class.md
+++ b/docs/adr/0012-one-window-per-loaded-class.md
@@ -1,0 +1,88 @@
+# One window per loaded Class — per-window DI scope
+
+Each loaded analysis (one Class) lives in its own top-level
+`MainWindow`, backed by its own **DI scope**. Scoped services
+(`IMessenger`, `HoverDelayService`, `StateService`, and all
+per-analysis ViewModels) get one instance per workspace. Stateless
+singletons (`ViolinPlotService`, `CorrelationPlotService`) stay shared
+across workspaces because they wrap expensive Python interop init.
+
+A `WorkspaceFactory` (app-singleton) wraps
+`IServiceScopeFactory.CreateScope()` and returns a disposable
+`Workspace` that owns the scope. The scope is disposed when the
+window closes, releasing the loaded `ClassAssessment`,
+`GradingSession`, plot ViewModels, and scoped services for GC.
+
+The static `WeakReferenceMessenger.Default` is **not used** anywhere
+in production code. Each scope receives a fresh
+`new WeakReferenceMessenger()` instance via the DI factory delegate.
+ViewModels expose their injected `IMessenger` as a public `Messenger`
+property so View code-behind can reach it through `DataContext`. Old
+code that referenced `WeakReferenceMessenger.Default` directly
+(`MainWindow`, `ViolinPlotControl`, `CorrelationPlotControl`,
+`StudentCardViewModel`, `ImageCopyService`,
+`PowerPointExportService`) has been migrated to the scoped messenger;
+`ImageCopyService` and `PowerPointExportService` now take an
+`IMessenger` parameter so the invoking window's messenger flows
+through.
+
+## Why
+
+The PRD problem statement (#25) calls out that today's app holds one
+Class at a time. We want a user to load N files and keep each in its
+own independent window — drag a cursor in window A, window B is
+untouched. The single-file assumption was baked into the static
+`WeakReferenceMessenger.Default` broadcast bus and the singleton
+`HoverDelayService`: any second window would share both with the
+first, crossing wires on every `StudentHoverMessage`,
+`StudentEditedMessage`, and hover-activation event.
+
+Per-window DI scoping makes cross-window contamination
+**structurally impossible**: window A's `ViolinPlotViewModel` is
+subscribed to *its* messenger, not the static one. A message sent
+in window B's scope is sent on a different instance entirely.
+
+## Considered alternatives
+
+- **A — Token-based message routing.** Keep the singleton messenger,
+  introduce a per-window token, register/send with the token. Caller
+  obligation grows everywhere a message is sent or registered; one
+  forgotten token leaks cross-window. Easy to get wrong, hard to
+  catch in review.
+- **B — Per-window messenger but global static `HoverDelayService`.**
+  Solves message routing but the hover service tracks "the current
+  hovered student" as a singleton field; two windows hovering
+  simultaneously would clobber each other's hover state.
+- **C — Multi-Class store inside a single window.** This is the
+  Candidate #2 sketch from issue #5: one window, an active-Class
+  concept, per-Class state keyed inside the store. Heavier. The
+  user-facing goal (multiple files independently) is satisfied more
+  directly by separate windows. A heavier Class Store is not
+  precluded — it can be filed separately later.
+
+## Consequences
+
+- Resolving `MainWindowViewModel` from the root `IServiceProvider`
+  now throws (scoped services can't be resolved from the root).
+  Every resolution must go through a `Workspace` produced by
+  `WorkspaceFactory.Create()` — startup, snapshot mode, and (in a
+  future slice) the *Open Another File* command.
+- `Workspace` is `IDisposable`. The owner — `App.axaml.cs` today, the
+  per-window lifecycle handler in a later slice — must dispose it
+  when the window closes. Not disposing it leaks the scoped
+  services until app shutdown.
+- View code-behind reaches the scoped messenger through
+  `DataContext` (the per-window VM). `DataContext`-set timing means
+  message registrations move from the View constructor into
+  `OnDataContextChanged`, guarded by a one-shot flag.
+- The test factory `MainWindowViewModel.CreateForTesting()` now
+  constructs a fresh `new WeakReferenceMessenger()` rather than
+  using `.Default`, which keeps test cases isolated from each other
+  (a quiet bonus).
+- A `WorkspaceFactoryTests` asserts the contract: two factory-produced
+  workspaces have distinct `IMessenger` and `HoverDelayService`
+  instances; messages sent in one don't reach the other; disposing
+  one doesn't affect the other.
+- This ADR's scoping decision is what slice 2 (#27) relies on to
+  introduce the *Open Another File* command. Slices 3–5 build on
+  it without changing the scoping shape.


### PR DESCRIPTION
## Summary

Introduces `WorkspaceFactory` + `Workspace` so each loaded Class can run
in its own DI scope. `IMessenger`, `HoverDelayService`, `StateService`,
and all per-analysis ViewModels become **scoped**; `ViolinPlotService`
and `CorrelationPlotService` stay **singleton** (stateless Python-interop
wrappers).

The static `WeakReferenceMessenger.Default` is removed from production
code — every send/register flows through the scoped messenger reached
via `DataContext`. This was originally under-scoped in #26's body; the
issue was updated to reflect the 21-site cleanup that actually has to
land for the scoping to mean anything.

No new user-visible behavior. The app still opens one window on startup.
Slice 2 (#27) adds the *Open Another File* command on top of this
foundation.

Closes #26.

## Test plan

- [x] `WorkspaceFactoryTests` (4 new tests) — distinct messengers/hover
      services per workspace; messages don't cross scopes; disposing
      one workspace doesn't affect another.
- [x] Full `dotnet test` suite passes (192/192).
- [x] Snapshot mode renders correctly with the IP exam fixture.
- [ ] **Manual smoke** (owner): launch app, load
      `IP exam scores 2025.xlsx`, drag a cursor, hover a student, edit a
      comment, copy a plot to clipboard — all work as on `main`.