### PR TITLE
feat(workspaces): Open Another File command (slice 2 of #25)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -11,8 +11,9 @@ _Avoid_: Subject, topic.
 
 **Class**: One specific offering of a Course — a particular semester
 with particular Students under a particular instructor. The same Course
-can have many Classes. *(Multi-Class handling is on the roadmap; today
-the app holds one Class at a time.)*
+can have many Classes. *Each loaded Class lives in its own top-level
+window with an independent DI scope; opening another file spawns a
+fresh window that does not share state with any other (see ADR-0012).*
 _Avoid_: Section, cohort, group.
 
 **Student**: A person enrolled in a Class.

--- a/Dotsesses/Services/WorkspaceFactory.cs
+++ b/Dotsesses/Services/WorkspaceFactory.cs
@@ -1,6 +1,9 @@
 namespace Dotsesses.Services;
 
 using System;
+using System.IO;
+using System.Threading.Tasks;
+using Dotsesses.UI;
 using Microsoft.Extensions.DependencyInjection;
 
 /// <summary>
@@ -19,4 +22,30 @@ public sealed class WorkspaceFactory
     }
 
     public Workspace Create() => new(_scopes.CreateScope());
+
+    /// <summary>
+    /// Creates a workspace, resolves its <see cref="MainWindowViewModel"/>,
+    /// and loads <paramref name="filePath"/> into it (xlsx via
+    /// <c>LoadFromExcelFile</c>, .dots via <c>LoadStateCommand</c>). The
+    /// returned workspace exposes the loaded VM through
+    /// <see cref="Workspace.Services"/>; the caller is responsible for
+    /// constructing and showing the Window.
+    /// </summary>
+    public async Task<Workspace> CreateForFileAsync(string filePath)
+    {
+        ArgumentNullException.ThrowIfNull(filePath);
+        var workspace = Create();
+        var vm = workspace.Services.GetRequiredService<MainWindowViewModel>();
+
+        if (Path.GetExtension(filePath).Equals(".dots", StringComparison.OrdinalIgnoreCase))
+        {
+            await vm.LoadStateCommand.ExecuteAsync(filePath);
+        }
+        else
+        {
+            vm.LoadFromExcelFile(filePath);
+        }
+
+        return workspace;
+    }
 }

--- a/Dotsesses/UI/MainWindow.axaml
+++ b/Dotsesses/UI/MainWindow.axaml
@@ -84,6 +84,10 @@
                         <!-- Save/Export Buttons -->
                         <Border Grid.Row="0" BorderBrush="#202020" BorderThickness="0,0,0,2" Padding="6,6,10,6">
                             <StackPanel Orientation="Horizontal" Spacing="8">
+                                <Button x:Name="OpenAnotherFileButton"
+                                        Classes="app"
+                                        Content="📂"
+                                        ToolTip.Tip="Open another file in a new window"/>
                                 <Button x:Name="SaveButton"
                                         Classes="app"
                                         ToolTip.Tip="Save state to file">

--- a/Dotsesses/UI/MainWindow.axaml.cs
+++ b/Dotsesses/UI/MainWindow.axaml.cs
@@ -163,6 +163,7 @@ public partial class MainWindow : Window
         DotPlotView.AddHandler(PointerMovedEvent, OnDotPlotPointerMoved, Avalonia.Interactivity.RoutingStrategies.Tunnel | Avalonia.Interactivity.RoutingStrategies.Bubble, handledEventsToo: true);
 
         // Wire up Save, Export, Settings, and Copy button click handlers
+        OpenAnotherFileButton.Click += OnOpenAnotherFileClick;
         SaveButton.Click += OnSaveButtonClick;
         ExportButton.Click += OnExportButtonClick;
         ExportPptxButton.Click += OnExportPptxButtonClick;
@@ -187,6 +188,12 @@ public partial class MainWindow : Window
     private async void OnSaveButtonClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
     {
         await SaveWithDialog();
+    }
+
+    private async void OnOpenAnotherFileClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (DataContext is not MainWindowViewModel vm) return;
+        await vm.OpenAnotherFileCommand.ExecuteAsync(this);
     }
 
     private void OnSettingsButtonClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)

--- a/Dotsesses/UI/MainWindowViewModel.cs
+++ b/Dotsesses/UI/MainWindowViewModel.cs
@@ -4,6 +4,8 @@ using System;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Platform.Storage;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
@@ -11,6 +13,7 @@ using Dotsesses.Calculators;
 using Dotsesses.Messages;
 using Dotsesses.Models;
 using Dotsesses.Services;
+using Microsoft.Extensions.DependencyInjection;
 using OxyPlot;
 using OxyPlot.Annotations;
 using OxyPlot.Axes;
@@ -38,6 +41,7 @@ public partial class MainWindowViewModel : ViewModelBase
     private readonly IMessenger _messenger = null!;
     private readonly HoverDelayService _hoverDelayService = null!;
     private readonly StateService _stateService = null!;
+    private readonly WorkspaceFactory? _workspaceFactory;
 
     /// <summary>
     /// Gets a fresh GradeAssigner built from the session's current
@@ -181,7 +185,8 @@ public partial class MainWindowViewModel : ViewModelBase
         ViolinPlotViewModel violinPlotViewModel,
         CorrelationPlotViewModel correlationPlotViewModel,
         HoverDelayService hoverDelayService,
-        StateService stateService)
+        StateService stateService,
+        WorkspaceFactory workspaceFactory)
     {
         Log("MainWindowViewModel: Constructor started");
 
@@ -190,6 +195,7 @@ public partial class MainWindowViewModel : ViewModelBase
         _correlationPlotViewModel = correlationPlotViewModel;
         _hoverDelayService = hoverDelayService;
         _stateService = stateService;
+        _workspaceFactory = workspaceFactory;
 
         // Create the tab container ViewModel
         _plotTabContainerViewModel = new PlotTabContainerViewModel(violinPlotViewModel, correlationPlotViewModel);
@@ -252,7 +258,8 @@ public partial class MainWindowViewModel : ViewModelBase
             null!,
             null!,
             new HoverDelayService(),
-            new StateService());
+            new StateService(),
+            null!);
     }
 
     /// <summary>
@@ -1225,6 +1232,52 @@ public partial class MainWindowViewModel : ViewModelBase
             Log($"Error saving state: {ex.Message}");
             throw;
         }
+    }
+
+    /// <summary>
+    /// Opens another analysis file in its own window. Each invocation
+    /// spawns a fresh DI scope, loads the file into the scope's
+    /// <see cref="MainWindowViewModel"/>, and shows a new
+    /// <see cref="MainWindow"/>. The new window is fully independent —
+    /// drags, hover, comments in one window do not affect any other.
+    /// See ADR-0012.
+    /// </summary>
+    /// <param name="parent">The invoking window — supplies the
+    /// <see cref="IStorageProvider"/> for the file picker.</param>
+    [RelayCommand]
+    private async Task OpenAnotherFile(Window? parent)
+    {
+        if (parent is null || _workspaceFactory is null) return;
+
+        var filePath = await PromptForFile(parent.StorageProvider);
+        if (string.IsNullOrEmpty(filePath)) return;
+
+        var workspace = await _workspaceFactory.CreateForFileAsync(filePath);
+        var newVm = workspace.Services.GetRequiredService<MainWindowViewModel>();
+
+        // Tag holds the workspace alive for the window's lifetime. Slice 3
+        // adds a Closed handler that disposes it; today the scope is reclaimed
+        // when the window is GC'd.
+        var window = new MainWindow { DataContext = newVm, Tag = workspace };
+        window.Show();
+    }
+
+    private static async Task<string?> PromptForFile(IStorageProvider storageProvider)
+    {
+        var result = await storageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = "Open another file",
+            AllowMultiple = false,
+            FileTypeFilter = new[]
+            {
+                new FilePickerFileType("Supported files") { Patterns = new[] { "*.xlsx", "*.xls", "*.dots" } },
+                new FilePickerFileType("Excel files") { Patterns = new[] { "*.xlsx", "*.xls" } },
+                new FilePickerFileType("Dotsesses files") { Patterns = new[] { "*.dots" } },
+                new FilePickerFileType("All files") { Patterns = new[] { "*" } }
+            }
+        });
+
+        return result.Count > 0 ? result[0].Path.LocalPath : null;
     }
 
     /// <summary>

--- a/SPEC.md
+++ b/SPEC.md
@@ -250,6 +250,18 @@ cleanly and silently migrate on first re-save. See ADR-0002.
 
 ## Loading score files
 
+On launch, the splash window prompts for a score file (`.xlsx`/`.xls`)
+or a saved state file (`.dots`). Pick one to open the main window with
+that Class loaded.
+
+Once a window is open, the **📂 Open Another File** button in the
+drill-down toolbar prompts for a second file and opens it in a **new
+top-level window**. Each window is fully independent — drags, hover,
+comment edits, and Settings in one window do not affect any other (see
+ADR-0012). Repeat the action to open as many files as needed; each
+gets its own window. Closing one window leaves siblings untouched.
+*(Lifecycle on the last window closing is covered in slice 3 / #28.)*
+
 Loading an `.xlsx` score file routes through `ScoreReader`. The reader
 tolerates messy spreadsheets — blank rows are skipped, missing cells
 in a score column drop only that one cell, and rows without a parseable


### PR DESCRIPTION
## Summary

Adds the first user-visible multi-window surface. A 📂 button in the
drill-down toolbar prompts for a file and opens it in a brand-new
top-level window backed by its own DI scope. Drags, hover, comment
edits, and Settings in one window do not affect any other.

Behind the seam:
- `WorkspaceFactory.CreateForFileAsync` resolves the scope's VM, loads
  the file (xlsx via `LoadFromExcelFile`, `.dots` via
  `LoadStateCommand`), and returns the workspace.
- `MainWindowViewModel.OpenAnotherFileCommand` (`[RelayCommand]`) picks
  the file via the invoking window's `IStorageProvider`, spawns the
  workspace, builds a new `MainWindow`, and parks the workspace on
  `Window.Tag`. Slice 3 (#28) adds proper disposal on close.
- `CONTEXT.md` and `SPEC.md` updated.

Closes #27.

## Test plan

- [x] Full `dotnet test` suite passes (192/192).
- [x] Snapshot mode still renders correctly (single-file path
      unchanged); the new 📂 button is visible top-left in the
      drill-down toolbar.
- [ ] **Manual smoke** (owner):
      - Load file A. Click 📂, pick file B. Two windows visible.
      - Drag a cursor in A; B's cursors stationary.
      - Hover a student in A; B's drill-down unchanged, B's violin
        plot doesn't highlight.
      - Edit a comment in A; only A's plots refresh.