### PR TITLE
feat(workspaces): window lifecycle (slice 3 of #25)

### DIFF
--- a/Dotsesses.Tests/Services/WorkspaceFactoryTests.cs
+++ b/Dotsesses.Tests/Services/WorkspaceFactoryTests.cs
@@ -81,4 +81,18 @@ public class WorkspaceFactoryTests
         Assert.True(received);
         GC.KeepAlive(receiver);
     }
+
+    [Fact]
+    public void Workspace_DisposeIsIdempotent()
+    {
+        // Window.Closed may fire more than once in degenerate Avalonia
+        // scenarios. Dispose must be safe to call repeatedly.
+        var factory = BuildFactoryWithMinimalRegistrations();
+        var workspace = factory.Create();
+
+        workspace.Dispose();
+        var ex = Record.Exception(() => workspace.Dispose());
+
+        Assert.Null(ex);
+    }
 }

--- a/Dotsesses/App.axaml.cs
+++ b/Dotsesses/App.axaml.cs
@@ -47,6 +47,11 @@ public partial class App : Application
         {
             Log("Desktop lifetime detected");
 
+            // Multi-window: app stays alive as long as any window is open.
+            // Default OnMainWindowClose would exit when the first-opened
+            // window closes, killing sibling analyses. See ADR-0012.
+            desktop.ShutdownMode = ShutdownMode.OnLastWindowClose;
+
             // Avoid duplicate validations from both Avalonia and the CommunityToolkit.
             // More info: https://docs.avaloniaui.net/docs/guides/development-guides/data-validation#manage-validationplugins
             DisableAvaloniaDataAnnotationValidation();
@@ -80,6 +85,7 @@ public partial class App : Application
                 };
 
                 desktop.MainWindow = _mainWindow;
+                _mainWindow.Closed += (_, _) => snapshotWorkspace.Dispose();
 
                 _mainWindow.Opened += async (s, e) =>
                 {
@@ -237,6 +243,12 @@ public partial class App : Application
                             {
                                 DataContext = viewModel,
                             };
+
+                            // Capture the workspace in a local so the Closed
+                            // handler keeps it alive and disposes it
+                            // deterministically when the window closes.
+                            var workspaceForClose = _initialWorkspace!;
+                            _mainWindow.Closed += (_, _) => workspaceForClose.Dispose();
 
                             Log("Startup: Showing MainWindow");
                             desktop.MainWindow = _mainWindow;

--- a/Dotsesses/UI/MainWindowViewModel.cs
+++ b/Dotsesses/UI/MainWindowViewModel.cs
@@ -1255,10 +1255,12 @@ public partial class MainWindowViewModel : ViewModelBase
         var workspace = await _workspaceFactory.CreateForFileAsync(filePath);
         var newVm = workspace.Services.GetRequiredService<MainWindowViewModel>();
 
-        // Tag holds the workspace alive for the window's lifetime. Slice 3
-        // adds a Closed handler that disposes it; today the scope is reclaimed
-        // when the window is GC'd.
-        var window = new MainWindow { DataContext = newVm, Tag = workspace };
+        // The Closed handler closure keeps the workspace alive for the window's
+        // lifetime and disposes the scope deterministically when the user closes
+        // the window — releasing the messenger, hover service, VMs, and loaded
+        // ClassAssessment for GC. See ADR-0012.
+        var window = new MainWindow { DataContext = newVm };
+        window.Closed += (_, _) => workspace.Dispose();
         window.Show();
     }
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -259,8 +259,10 @@ drill-down toolbar prompts for a second file and opens it in a **new
 top-level window**. Each window is fully independent — drags, hover,
 comment edits, and Settings in one window do not affect any other (see
 ADR-0012). Repeat the action to open as many files as needed; each
-gets its own window. Closing one window leaves siblings untouched.
-*(Lifecycle on the last window closing is covered in slice 3 / #28.)*
+gets its own window. Closing one window leaves siblings untouched;
+the app exits only when the **last** window is closed. Each window's
+DI scope is disposed deterministically on close, releasing the
+loaded Class for GC.
 
 Loading an `.xlsx` score file routes through `ScoreReader`. The reader
 tolerates messy spreadsheets — blank rows are skipped, missing cells


### PR DESCRIPTION
## Summary

App stays alive while any window is open and exits when the last one
closes. Each window's DI scope is disposed deterministically on
`Window.Closed` — splash startup, snapshot mode, and *Open Another
File* all wire a closure-captured disposal handler. The slice 2
`Window.Tag = workspace` placeholder is gone.

Key changes:
- `desktop.ShutdownMode = ShutdownMode.OnLastWindowClose` in
  `App.OnFrameworkInitializationCompleted` — default was
  `OnMainWindowClose` which would have killed siblings.
- Three `Window.Closed += (_, _) => workspace.Dispose()` wirings (one
  per window-creation path).
- New test `Workspace_DisposeIsIdempotent` covers the closed-twice
  edge case.
- `SPEC.md` lifecycle parenthetical replaced with the real behavior.

Closes #28.

## Test plan

- [x] Full `dotnet test` suite passes (193/193 — one new).
- [x] Snapshot mode still renders correctly.
- [ ] **Manual smoke** (owner):
      - Open 3 files (windows A, B, C). Close B → A and C still
        working. Close A → C continues. Close C → app exits.
      - Open Settings from B, toggle a `ScoreSelection`'s Aggregate
        flag, Apply → only B's plots reseed; A's untouched.
      - Open comment editor from A → only A's plots refresh on save.
      - Open-and-close 10 windows in sequence; working set plateaus
        (no linear leak).