### PR TITLE
feat(workspaces): shared LastUsedDirectory across windows (slice 4 of #25)

### DIFF
--- a/Dotsesses/App.axaml.cs
+++ b/Dotsesses/App.axaml.cs
@@ -347,7 +347,11 @@ public partial class App : Application
 
         // Scoped: one per workspace.
         services.AddScoped<HoverDelayService>();
-        services.AddScoped<StateService>();
+
+        // StateService is app-singleton so LastUsedDirectory is shared across
+        // windows — saving in one window primes the file picker in any other.
+        // The save/load methods themselves are stateless (no per-window data).
+        services.AddSingleton<StateService>();
 
         // Workspace factory — wraps IServiceScopeFactory to produce per-window
         // scopes. App-singleton so each Open Another call resolves the same

--- a/Dotsesses/UI/MainWindowViewModel.cs
+++ b/Dotsesses/UI/MainWindowViewModel.cs
@@ -271,6 +271,7 @@ public partial class MainWindowViewModel : ViewModelBase
         Log($"MainWindowViewModel: Loading from Excel file: {excelFilePath}");
 
         _currentSourceFile = excelFilePath;
+        _stateService.LastUsedDirectory = Path.GetDirectoryName(excelFilePath);
 
         var scoreReader = new ScoreReader();
         var readResult = scoreReader.Read(excelFilePath);
@@ -1249,7 +1250,7 @@ public partial class MainWindowViewModel : ViewModelBase
     {
         if (parent is null || _workspaceFactory is null) return;
 
-        var filePath = await PromptForFile(parent.StorageProvider);
+        var filePath = await PromptForFile(parent.StorageProvider, _stateService.LastUsedDirectory);
         if (string.IsNullOrEmpty(filePath)) return;
 
         var workspace = await _workspaceFactory.CreateForFileAsync(filePath);
@@ -1264,12 +1265,19 @@ public partial class MainWindowViewModel : ViewModelBase
         window.Show();
     }
 
-    private static async Task<string?> PromptForFile(IStorageProvider storageProvider)
+    private static async Task<string?> PromptForFile(IStorageProvider storageProvider, string? suggestedDirectory)
     {
+        IStorageFolder? startLocation = null;
+        if (!string.IsNullOrEmpty(suggestedDirectory) && Directory.Exists(suggestedDirectory))
+        {
+            startLocation = await storageProvider.TryGetFolderFromPathAsync(suggestedDirectory);
+        }
+
         var result = await storageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
         {
             Title = "Open another file",
             AllowMultiple = false,
+            SuggestedStartLocation = startLocation,
             FileTypeFilter = new[]
             {
                 new FilePickerFileType("Supported files") { Patterns = new[] { "*.xlsx", "*.xls", "*.dots" } },


### PR DESCRIPTION
## Summary

`StateService` is now an app-singleton (was scoped) so its
`LastUsedDirectory` is shared across every open window. Saving or
loading in one window primes the file picker in any other.

Changes:
- `App.ConfigureServices`: `AddScoped<StateService>` →
  `AddSingleton<StateService>`. Service is otherwise stateless — its
  methods don't touch per-window data.
- `LoadFromExcelFile` now stamps `LastUsedDirectory` (previously only
  `.dots` save/load did), so an xlsx load counts toward "last seen
  directory."
- *Open Another File* picker reads `LastUsedDirectory` via
  `SuggestedStartLocation`.
- The existing Save dialog in `MainWindow.axaml.cs:438` already fell
  back to `LastUsedDirectory` when the source was unknown; it picks up
  cross-window sharing for free.

Per-window save state (`_currentSourceFile`, `SourceFileName`,
`HasUnsavedChanges`) was already on the VM — verified, no changes
needed there.

Closes #29.

## Test plan

- [x] `dotnet test` passes (193/193).
- [x] Snapshot mode still renders correctly.
- [ ] **Manual smoke** (owner):
      - Open file from `/Users/foo/dataA/`. Click 📂 → picker starts in
        `/Users/foo/dataA/`.
      - In window A, Save As into `/Users/foo/dataB/`. Click 📂 in
        another window → picker starts in `/Users/foo/dataB/`.
      - Save A → A's title updates, B's title unchanged.
      - Save B as `.dots`; reload via Open Another in a fresh window →
        cursors, EnabledGrades, ScoreSelections, comments restored.