### PR TITLE
feat(workspaces): window title with unsaved indicator (slice 5 of #25)

### DIFF
--- a/Dotsesses/UI/MainWindow.axaml
+++ b/Dotsesses/UI/MainWindow.axaml
@@ -10,7 +10,7 @@
         x:Class="Dotsesses.UI.MainWindow"
         x:DataType="vm:MainWindowViewModel"
         Icon="/Assets/avalonia-logo.ico"
-        Title="{Binding SourceFileName, StringFormat='Dotsesses - {0}'}"
+        Title="{Binding WindowTitle}"
         Width="1200" Height="800"
         WindowStartupLocation="CenterScreen">
 

--- a/Dotsesses/UI/MainWindowViewModel.cs
+++ b/Dotsesses/UI/MainWindowViewModel.cs
@@ -105,13 +105,24 @@ public partial class MainWindowViewModel : ViewModelBase
     private PlotTabContainerViewModel? _plotTabContainerViewModel;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(WindowTitle))]
     private bool _hasUnsavedChanges;
 
     [ObservableProperty]
     private string? _currentSaveFilePath;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(WindowTitle))]
     private string _sourceFileName = "No file loaded";
+
+    /// <summary>
+    /// The full window title — file name plus an unsaved-changes dot
+    /// (matching the Save button's indicator). Lets OS task switchers
+    /// distinguish multiple open analyses at a glance. See ADR-0012.
+    /// </summary>
+    public string WindowTitle => HasUnsavedChanges
+        ? $"Dotsesses - {SourceFileName} ●"
+        : $"Dotsesses - {SourceFileName}";
 
     /// <summary>
     /// Gets the full path to the current source file.


### PR DESCRIPTION
## Summary

Adds a `WindowTitle` computed property on `MainWindowViewModel` that
combines `SourceFileName` with a trailing `●` when
`HasUnsavedChanges` — mirroring the Save button's existing indicator.
The XAML `Title` binding moves from inline `StringFormat` to bind
`WindowTitle` directly so the format lives in one place and updates
live as the unsaved-state flips.

`[NotifyPropertyChangedFor(nameof(WindowTitle))]` on both source
fields handles the live refresh.

Multiple open windows are now visually distinguishable in the OS task
switcher / Mission Control.

Closes #30.

## Test plan

- [x] `dotnet test` passes (193/193).
- [x] Snapshot mode still renders correctly.
- [ ] **Manual smoke** (owner):
      - Open file A → title shows `Dotsesses - A.xlsx`.
      - Open Another, load file B → both windows show distinct titles
        in Mission Control.
      - Edit a comment in A → A's title gains the ` ●` indicator.
      - Save A → indicator clears.