### PR TITLE
feat(significance): inferential layer, PowerPoint export, + hover scope fix

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -46,9 +46,23 @@ continuous column within that subgroup) with a ±SEM error bar.
 Numeric column with `Significance=true`, one column per
 StudentAttribute (Categorical) column with `Significance=true`. Each
 cell answers: "does subgroup membership in this categorical column
-materially shift the average of this numeric column?" v3 of the plot
-is descriptive (mean + SEM dots); a future inferential layer will add
-per-cell p-values. See ADR-0014.
+materially shift the average of this numeric column?" The descriptive
+layer plots mean + SEM dots per Subgroup; the inferential layer
+(slice 4) overlays each cell's **Significance Test** p-value and stars.
+The matrix is an *exploratory screening* view — p-values are raw
+(uncorrected for the many cells tested). See ADR-0014.
+
+**Significance Test**: The per-cell omnibus test the Significance Matrix
+runs over a cell's Subgroups to produce its p-value. One **Test Family**
+is chosen for the whole matrix (a top-of-plot selector, persisted with the
+workspace): *parametric* = Welch's ANOVA (unequal-variance-safe; reduces
+to Welch's t for 2 Subgroups), *non-parametric* = Kruskal–Wallis
+(rank-based; reduces to Mann–Whitney for 2 Subgroups). The same family
+covers categorical columns with 2 or 2+ values — no per-cell branching.
+Subgroups with N<2 are dropped from the test; a cell with fewer than 2
+remaining Subgroups is untestable (shows an em-dash). Significance tiers
+follow the universal convention: `*` p<.05, `**` p<.01, `***`
+p<.001.
 
 **AggregateScore**: The sum of a Student's Scores whose `(Name, Index)`
 is in the active ScoreSelection aggregate set. Used for x-axis position

--- a/Dotsesses.Tests/Services/StateServiceTests.cs
+++ b/Dotsesses.Tests/Services/StateServiceTests.cs
@@ -74,7 +74,7 @@ public class StateServiceTests : IDisposable
 
         // Assert
         Assert.NotNull(loadedState);
-        Assert.Equal(4, loadedState.Version);
+        Assert.Equal(5, loadedState.Version);
         Assert.Equal("original_source.xlsx", loadedState.SourceFile);
         Assert.Equal(2, loadedState.Students.Count);
         // Slots are A, B, C (post-#18 fix: catch-all is F, lowest in
@@ -210,12 +210,51 @@ public class StateServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task SaveAsync_WritesVersion4()
+    public async Task SaveAsync_WritesVersion5()
     {
-        var filePath = Path.Combine(_testDirectory, "v4_check.json");
+        var filePath = Path.Combine(_testDirectory, "v5_check.json");
         await _stateService.SaveAsync(filePath, CreateTestStudents(), TestFixtures.SessionForGrading(), Array.Empty<ScoreSelection>());
         var json = await File.ReadAllTextAsync(filePath);
-        Assert.Contains("\"version\": 4", json);
+        Assert.Contains("\"version\": 5", json);
+    }
+
+    [Fact]
+    public async Task SaveAsync_RoundTripsSignificanceTestFamily()
+    {
+        var filePath = Path.Combine(_testDirectory, "test_family.json");
+        await _stateService.SaveAsync(
+            filePath, CreateTestStudents(), TestFixtures.SessionForGrading(),
+            Array.Empty<ScoreSelection>(), sourceFile: null,
+            significanceTestFamily: SignificanceTestFamily.Nonparametric);
+
+        var loaded = await _stateService.LoadAsync(filePath);
+
+        Assert.Equal(SignificanceTestFamily.Nonparametric, loaded.SignificanceTestFamily);
+    }
+
+    [Fact]
+    public async Task LoadAsync_V4Json_DefaultsSignificanceTestFamilyToParametric()
+    {
+        // A v4 file predates the inferential layer and has no
+        // significanceTestFamily field — it must silently migrate to the
+        // Parametric default (ADR-0002 / ADR-0014).
+        var filePath = Path.Combine(_testDirectory, "v4_legacy.json");
+        var v4Content = """
+            {
+              "version": 4,
+              "savedAt": "2024-01-01T00:00:00Z",
+              "sourceFile": "legacy.xlsx",
+              "students": [],
+              "cursors": [],
+              "scoreSelections": []
+            }
+            """;
+        await File.WriteAllTextAsync(filePath, v4Content);
+
+        var loaded = await _stateService.LoadAsync(filePath);
+
+        Assert.Equal(4, loaded.Version);
+        Assert.Equal(SignificanceTestFamily.Parametric, loaded.SignificanceTestFamily);
     }
 
     [Fact]

--- a/Dotsesses/Models/SavedState.cs
+++ b/Dotsesses/Models/SavedState.cs
@@ -7,12 +7,21 @@ namespace Dotsesses.Models;
 /// </summary>
 public class SavedState
 {
-    public int Version { get; set; } = 4;
+    public int Version { get; set; } = 5;
     public DateTime SavedAt { get; set; }
     public string? SourceFile { get; set; }
     public List<SavedStudent> Students { get; set; } = new();
     public List<SavedCursor> Cursors { get; set; } = new();
     public List<SavedScoreSelection> ScoreSelections { get; set; } = new();
+
+    /// <summary>
+    /// The Significance Matrix's per-cell omnibus test family (ADR-0014
+    /// slice 4). Defaults to <see cref="SignificanceTestFamily.Parametric"/>
+    /// so v4 files (which lack this field) silently migrate to the parametric
+    /// default on load, per the ADR-0002 first-save-rewrites pattern.
+    /// </summary>
+    public SignificanceTestFamily SignificanceTestFamily { get; set; }
+        = SignificanceTestFamily.Parametric;
 }
 
 /// <summary>

--- a/Dotsesses/Models/SignificanceDataPoint.cs
+++ b/Dotsesses/Models/SignificanceDataPoint.cs
@@ -5,8 +5,10 @@ namespace Dotsesses.Models;
 /// <c>Subgroup</c> of a Categorical column averaged against a Numeric column
 /// (see CONTEXT.md). Unlike <see cref="CorrelationDataPoint"/>, the dot does
 /// not represent an individual student — it summarises the subgroup's
-/// students. The point shape leaves room for a future per-cell <c>PValue</c>
-/// field when slice 4 layers in the inferential test (see ADR-0014).
+/// students. Slice 4 (ADR-0014) layers in the inferential test: every dot
+/// in a cell carries that cell's omnibus <see cref="PValue"/> (null when the
+/// cell is untestable) and a flag for whether its subgroup was
+/// <see cref="Excluded"/> from the test for being too small (N&lt;2).
 /// </summary>
 public record SignificanceDataPoint(
     int CellRow,
@@ -19,4 +21,7 @@ public record SignificanceDataPoint(
     double Mean,
     double Sem,
     int N,
-    string Color);
+    string Color,
+    double? PValue = null,
+    SignificanceTestFamily TestFamily = SignificanceTestFamily.Parametric,
+    bool Excluded = false);

--- a/Dotsesses/Models/SignificanceTestFamily.cs
+++ b/Dotsesses/Models/SignificanceTestFamily.cs
@@ -1,0 +1,19 @@
+namespace Dotsesses.Models;
+
+/// <summary>
+/// The omnibus statistical test run per cell of the Significance Matrix
+/// (see ADR-0014 slice 4). Both families are robust and reduce cleanly to
+/// their two-group equivalents, so a single code path covers categorical
+/// columns with 2 or 2+ values:
+/// <list type="bullet">
+///   <item><see cref="Parametric"/> — Welch's ANOVA (unequal-variance-safe;
+///   reduces to Welch's t for 2 groups).</item>
+///   <item><see cref="Nonparametric"/> — Kruskal–Wallis (rank-based;
+///   reduces to Mann–Whitney for 2 groups).</item>
+/// </list>
+/// </summary>
+public enum SignificanceTestFamily
+{
+    Parametric,
+    Nonparametric,
+}

--- a/Dotsesses/Python/Violin/significance_matrix.py
+++ b/Dotsesses/Python/Violin/significance_matrix.py
@@ -21,10 +21,24 @@ Small-N handling:
 - N=1 → render dot, no error bar.
 - N≥2 → render dot + SEM error bar.
 
+Inferential layer (ADR-0014, "slice 4"): each cell runs ONE omnibus test
+over its subgroups and prints the resulting p-value + tiered significance
+stars in the cell corner. The `test_family` argument switches all cells
+between two robust families:
+- 'parametric'    → Welch's ANOVA (unequal-variance-safe; reduces to
+                    Welch's t for 2 groups).
+- 'nonparametric' → Kruskal–Wallis (rank-based; reduces to Mann–Whitney
+                    for 2 groups).
+Subgroups with N<2 are dropped from the test (no within-group variance);
+the cell is testable only if ≥2 valid groups remain, otherwise it shows
+an em-dash. p-values are RAW (uncorrected) — the matrix is an exploratory
+screening view, not a confirmatory multiple-comparison procedure.
+
 Returns: (timing_dict, svg_string, point_data_list). Each point dict has
-{cell_row, cell_col, x, y, cat_col, num_col, subgroup, mean, sem, n, color}.
-The shape leaves room for a future `p_value` field per cell when slice 4
-adds the inferential test (see ADR-0014).
+{cell_row, cell_col, x, y, cat_col, num_col, subgroup, mean, sem, n, color,
+p_value, test_family, excluded}. `p_value` is the cell's omnibus p (NaN
+when the cell is untestable) and is repeated on every dot in the cell;
+`excluded` flags a dot whose subgroup was dropped from the test (N<2).
 """
 import math
 import time
@@ -35,6 +49,7 @@ import matplotlib
 matplotlib.use('Agg')  # Non-interactive backend
 import matplotlib.pyplot as plt
 import numpy as np
+from scipy import stats as _stats
 
 
 def apply_theme(theme: str = 'dark'):
@@ -71,12 +86,113 @@ def get_subgroup_color(idx: int) -> str:
     return CYCLING_PALETTE[idx % len(CYCLING_PALETTE)]
 
 
+def _welch_anova_pvalue(groups: List[List[float]]) -> Optional[float]:
+    """
+    Welch's ANOVA p-value (unequal-variance one-way ANOVA, Welch 1951).
+
+    scipy has no built-in Welch ANOVA (`f_oneway` assumes equal variance),
+    so we compute the closed form directly. For exactly 2 groups this equals
+    the two-sided Welch's t-test p-value (F = t²). Returns None when the test
+    is undefined — fewer than 2 groups, or any included group has zero
+    within-group variance (all-tied values make the Welch weight infinite).
+    """
+    k = len(groups)
+    if k < 2:
+        return None
+    ns = [len(g) for g in groups]
+    means = [float(np.mean(g)) for g in groups]
+    variances = [float(np.var(g, ddof=1)) for g in groups]
+    if any(v <= 0.0 for v in variances):
+        return None
+
+    weights = [n / v for n, v in zip(ns, variances)]
+    w_total = sum(weights)
+    grand_mean = sum(w * m for w, m in zip(weights, means)) / w_total
+
+    numer = sum(w * (m - grand_mean) ** 2 for w, m in zip(weights, means)) / (k - 1)
+    # Σ (1 - w_i/W)² / (n_i - 1)
+    tail = sum((1.0 - w / w_total) ** 2 / (n - 1) for w, n in zip(weights, ns))
+    denom = 1.0 + (2.0 * (k - 2) / (k ** 2 - 1)) * tail
+    f_stat = numer / denom
+
+    df1 = k - 1
+    df2 = 1.0 / ((3.0 / (k ** 2 - 1)) * tail)
+    return float(_stats.f.sf(f_stat, df1, df2))
+
+
+def _kruskal_pvalue(groups: List[List[float]]) -> Optional[float]:
+    """
+    Kruskal–Wallis H-test p-value. For 2 groups this reduces to the
+    Mann–Whitney U test. Returns None when undefined (fewer than 2 groups,
+    or scipy rejects the input, e.g. every value identical across groups).
+    """
+    if len(groups) < 2:
+        return None
+    try:
+        _, p = _stats.kruskal(*groups)
+    except ValueError:
+        return None
+    return None if (p is None or math.isnan(p)) else float(p)
+
+
+def compute_cell_pvalue(
+    subgroup_to_values: Dict[str, List[float]],
+    test_family: str,
+) -> Tuple[Optional[float], set]:
+    """
+    Run the per-cell omnibus test over a cell's subgroups.
+
+    Subgroups with N<2 are dropped (no within-group variance to test); the
+    cell is testable only if ≥2 valid groups remain. Returns
+    (p_value_or_None, excluded_subgroup_labels).
+    """
+    valid_groups: List[List[float]] = []
+    excluded: set = set()
+    for sg, values in subgroup_to_values.items():
+        if len(values) >= 2:
+            valid_groups.append(values)
+        elif len(values) >= 1:
+            excluded.add(sg)
+
+    if len(valid_groups) < 2:
+        return (None, excluded)
+
+    if test_family == 'nonparametric':
+        return (_kruskal_pvalue(valid_groups), excluded)
+    return (_welch_anova_pvalue(valid_groups), excluded)
+
+
+def _format_pvalue_annotation(p: Optional[float]) -> Tuple[str, bool]:
+    """
+    Build the in-cell annotation label and whether it is significant.
+
+    Tiers follow the universal convention: * p<.05, ** p<.01, *** p<.001.
+    Untestable cells (p is None) render an em-dash. Returns (label, is_sig).
+    """
+    if p is None:
+        return ('—', False)
+    if p < 0.001:
+        stars = '***'
+        p_text = 'p<.001'
+    else:
+        if p < 0.01:
+            stars = '**'
+        elif p < 0.05:
+            stars = '*'
+        else:
+            stars = ''
+        p_text = 'p=' + f'{p:.3f}'.lstrip('0')  # e.g. 'p=.003'
+    label = (p_text + ' ' + stars).strip()
+    return (label, bool(stars))
+
+
 def create_significance_matrix(
     fig_size: Tuple[float, float],
     numeric_series: List[Tuple[str, Dict[str, float]]],
     categorical_series: List[Tuple[str, Dict[str, str]]],
     theme: str = 'dark',
     dot_size: float = 5.0,
+    test_family: str = 'parametric',
 ) -> Tuple[Dict[str, int], str, List[Dict]]:
     """
     Build the significance matrix.
@@ -88,6 +204,9 @@ def create_significance_matrix(
     categorical_series : list of (column_name, {student_id_str: subgroup_string})
     theme : 'dark' or 'light'
     dot_size : marker radius in points (squared internally for scatter size)
+    test_family : 'parametric' (Welch's ANOVA) or 'nonparametric'
+        (Kruskal–Wallis) — the omnibus test run per cell for the in-cell
+        p-value annotation.
 
     Returns
     -------
@@ -121,6 +240,9 @@ def create_significance_matrix(
     # ----- Subgroup stats per cell -----
     # cell_stats[(i, j)] = list of (subgroup_label, mean, sem, n) in alpha order
     cell_stats: Dict[Tuple[int, int], List[Tuple[str, float, float, int]]] = {}
+    # cell_pvalues[(i, j)] = (p_value_or_None, excluded_subgroup_labels) from
+    # the per-cell omnibus test (see compute_cell_pvalue / ADR-0014 slice 4).
+    cell_pvalues: Dict[Tuple[int, int], Tuple[Optional[float], set]] = {}
     # Also collect per categorical column the canonical subgroup → color-index
     # map so the same subgroup gets the same color across all rows in a column.
     column_subgroup_index: Dict[int, Dict[str, int]] = {}
@@ -155,6 +277,7 @@ def create_significance_matrix(
                     sem = float('nan')  # undefined for N=1
                 row_stats.append((sg, mean_val, sem, n))
             cell_stats[(i, j)] = row_stats
+            cell_pvalues[(i, j)] = compute_cell_pvalue(subgroup_to_values, test_family)
 
     # ----- Per-row y-limits: [min(m-SEM), max(m+SEM)] +/- 5% padding -----
     row_ylims: Dict[int, Tuple[float, float]] = {}
@@ -190,6 +313,11 @@ def create_significance_matrix(
                              sharex='col',
                              gridspec_kw={'hspace': 0})
     label_color = '#555555' if theme == 'light' else '#B4B4B4'
+    # Significance annotation colors: strong/dark for significant cells (drawn
+    # bold), faint grey for non-significant / untestable cells.
+    sig_text_color = '#111111' if theme == 'light' else '#FFFFFF'
+    faint_text_color = '#999999'
+    anno_bbox_color = '#FFFFFF' if theme == 'light' else '#202020'
 
     # Track which (i, j) cells actually got a scatter call so we can map
     # SVG PathCollection groups back to them in order.
@@ -249,6 +377,25 @@ def create_significance_matrix(
             ax.scatter(xs, ys, s=dot_size ** 2, c=colors,
                        edgecolors='none', alpha=0.9, zorder=3)
             scatter_cells.append((i, j))
+
+            # In-cell significance annotation (top-right corner). Significant
+            # cells render bold + tiered stars in a strong color; non-sig /
+            # untestable cells render faint. Skipped entirely for cells with no
+            # dots at all (nothing was tested and nothing is shown).
+            p_val, _excluded = cell_pvalues.get((i, j), (None, set()))
+            if stats:
+                anno_label, anno_sig = _format_pvalue_annotation(p_val)
+                ax.text(
+                    0.97, 0.95, anno_label,
+                    transform=ax.transAxes,
+                    ha='right', va='top',
+                    fontsize=6.5,
+                    fontweight='bold' if anno_sig else 'normal',
+                    color=sig_text_color if anno_sig else faint_text_color,
+                    zorder=5,
+                    bbox=dict(facecolor=anno_bbox_color, alpha=0.55,
+                              edgecolor='none', pad=1.0),
+                )
 
             # Cell axes
             y_lo, y_hi = row_ylims[i]
@@ -327,6 +474,7 @@ def create_significance_matrix(
         num_name, _ = numeric_series[i]
         sg_to_idx = column_subgroup_index[j]
 
+        cell_p, cell_excluded = cell_pvalues.get((i, j), (None, set()))
         if len(svg_points) == len(stats):
             for k, (sg, mean_val, sem, n) in enumerate(stats):
                 color_idx = sg_to_idx.get(sg, 0)
@@ -342,6 +490,12 @@ def create_significance_matrix(
                     'sem': float(sem) if not math.isnan(sem) else float('nan'),
                     'n': int(n),
                     'color': get_subgroup_color(color_idx),
+                    # Cell-level omnibus p, repeated on every dot in the cell
+                    # (NaN when untestable); `excluded` flags a dot dropped
+                    # from the test for N<2. See ADR-0014 slice 4.
+                    'p_value': float(cell_p) if cell_p is not None else float('nan'),
+                    'test_family': test_family,
+                    'excluded': bool(sg in cell_excluded),
                 })
 
         # Remove the rendered <use> elements from the SVG; the dots will be

--- a/Dotsesses/Services/PowerPointExportService.cs
+++ b/Dotsesses/Services/PowerPointExportService.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls;
 using Avalonia.Media.Imaging;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.Messaging;
+using Dotsesses.Models;
 using Dotsesses.UI;
 using ShapeCrawler;
 
@@ -26,15 +27,18 @@ public class PowerPointExportService
     private const int ContentY = 50;
     private const int ContentWidth = 860;  // SlideWidth - 2*MarginX
     private const int MaxContentHeight = 460; // SlideHeight - ContentY - margin
+    private const int FooterHeight = 28; // bottom caption band (points)
 
     /// <summary>
-    /// Exports a complete presentation with DotPlot, ViolinPlot, CorrelationPlot, and grade table.
+    /// Exports a complete presentation with DotPlot, ViolinPlot, CorrelationPlot,
+    /// SignificanceMatrix, and grade table.
     /// </summary>
     public async Task ExportAsync(
         string outputPath,
         Control dotPlotControl,
         Control violinPlotControl,
         Control correlationPlotControl,
+        Control significancePlotControl,
         PlotTabContainerViewModel tabViewModel,
         IEnumerable<ComplianceRowViewModel> complianceRows,
         IMessenger messenger,
@@ -72,10 +76,29 @@ public class PowerPointExportService
             ClearPlaceholders(pres, 3);
             await AddPlotSlideAsync(pres, 3, $"{className} - Score Correlations", correlationPlotControl, messenger, restoreTheme: false);
 
-            // Slide 4: Grade Table (no rendering needed)
+            // Slide 4: SignificanceMatrix - switch to significance tab first
+            await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                tabViewModel.SelectSignificanceCommand.Execute(null);
+            });
+            // Allow layout + Python plot regeneration in light theme
+            await Task.Delay(500);
+
+            // Capture the active test family so the slide footer documents
+            // exactly which metric produced the cell p-values and stars.
+            var testFamily = await Dispatcher.UIThread.InvokeAsync(() =>
+                (significancePlotControl.DataContext as SignificancePlotViewModel)?.TestFamily
+                    ?? SignificanceTestFamily.Parametric);
+
             pres.Slides.Add(1);
             ClearPlaceholders(pres, 4);
-            AddGradeTableSlide(pres, 4, $"{className} - Grade Breakdown", complianceRows);
+            await AddPlotSlideAsync(pres, 4, $"{className} - Subgroup Significance", significancePlotControl, messenger, restoreTheme: false,
+                footer: BuildSignificanceFooter(testFamily));
+
+            // Slide 5: Grade Table (no rendering needed)
+            pres.Slides.Add(1);
+            ClearPlaceholders(pres, 5);
+            AddGradeTableSlide(pres, 5, $"{className} - Grade Breakdown", complianceRows);
 
             // Delete existing file if it exists (ShapeCrawler doesn't overwrite cleanly)
             if (File.Exists(outputPath))
@@ -119,7 +142,8 @@ public class PowerPointExportService
         string title,
         Control plotControl,
         IMessenger messenger,
-        bool restoreTheme = true)
+        bool restoreTheme = true,
+        string? footer = null)
     {
         var shapes = pres.Slide(slideNumber).Shapes;
 
@@ -139,20 +163,25 @@ public class PowerPointExportService
         // Reset stream position for ShapeCrawler
         imageStream.Position = 0;
 
+        // Reserve vertical space at the bottom for a footer when present, so
+        // the plot image is centered above it rather than overlapping it.
+        var footerReserve = footer != null ? FooterHeight : 0;
+        var maxContentHeight = MaxContentHeight - footerReserve;
+
         // Calculate dimensions: full width, height scaled to maintain aspect ratio
         var targetWidth = ContentWidth;
         var targetHeight = (int)(targetWidth * aspectRatio);
 
         // If height exceeds max, scale down from height instead
-        if (targetHeight > MaxContentHeight)
+        if (targetHeight > maxContentHeight)
         {
-            targetHeight = MaxContentHeight;
+            targetHeight = maxContentHeight;
             targetWidth = (int)(targetHeight / aspectRatio);
         }
 
         // Calculate centered position (horizontally centered, vertically centered in content area)
         var x = (SlideWidth - targetWidth) / 2;
-        var contentAreaHeight = SlideHeight - ContentY;
+        var contentAreaHeight = SlideHeight - ContentY - footerReserve;
         var y = ContentY + (contentAreaHeight - targetHeight) / 2;
 
         // Add plot image
@@ -164,6 +193,58 @@ public class PowerPointExportService
         picture.Y = y;
         picture.Width = targetWidth;
         picture.Height = targetHeight;
+
+        if (footer != null)
+        {
+            AddFooter(pres, slideNumber, footer);
+        }
+    }
+
+    /// <summary>
+    /// Adds a small, full-width caption text box pinned to the bottom of the
+    /// slide — used to document the metric behind a plot (e.g. the
+    /// Significance Matrix's per-cell test and star legend).
+    /// </summary>
+    private void AddFooter(Presentation pres, int slideNumber, string footer)
+    {
+        var shapes = pres.Slide(slideNumber).Shapes;
+        shapes.AddShape(
+            x: MarginX,
+            y: SlideHeight - FooterHeight,
+            width: ContentWidth,
+            height: FooterHeight - 4,
+            Geometry.Rectangle,
+            footer);
+
+        var footerShape = shapes.Last();
+        footerShape.Fill?.SetNoFill();
+        footerShape.Outline?.SetNoOutline();
+        footerShape.SetFontColor("555555");
+
+        var textBox = footerShape.TextBox;
+        if (textBox != null && textBox.Paragraphs.Count > 0)
+        {
+            var paragraph = textBox.Paragraphs[0];
+            if (paragraph.Portions.Count > 0)
+            {
+                var portion = paragraph.Portions[0];
+                portion.Font.Size = 10;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Builds the Significance Matrix slide footer describing the per-cell
+    /// omnibus test that produced the cell p-values and stars, the star tiers,
+    /// and that the p-values are raw (exploratory). See ADR-0015.
+    /// </summary>
+    private static string BuildSignificanceFooter(SignificanceTestFamily testFamily)
+    {
+        var testName = testFamily == SignificanceTestFamily.Nonparametric
+            ? "Kruskal–Wallis (non-parametric)"
+            : "Welch's ANOVA (parametric)";
+        return $"Per-cell test: {testName}.  Stars: * p<.05   ** p<.01   *** p<.001.  " +
+               "Raw, uncorrected p-values — exploratory screening.";
     }
 
     /// <summary>

--- a/Dotsesses/Services/SignificancePlotService.cs
+++ b/Dotsesses/Services/SignificancePlotService.cs
@@ -28,12 +28,14 @@ public class SignificancePlotService
     /// <param name="categoricalSeries">List of (column name, {student id → subgroup string}).</param>
     /// <param name="dotSize">Marker radius in points.</param>
     /// <param name="theme">Theme name (dark / light).</param>
+    /// <param name="testFamily">Omnibus test run per cell (see ADR-0014).</param>
     public (string SvgContent, List<SignificanceDataPoint> DataPoints) GeneratePlot(
         (double Width, double Height) figSize,
         List<(string Name, Dictionary<string, double> Values)> numericSeries,
         List<(string Name, Dictionary<string, string> Subgroups)> categoricalSeries,
         double dotSize = 5.0,
-        ThemeName theme = ThemeName.DarkMode)
+        ThemeName theme = ThemeName.DarkMode,
+        SignificanceTestFamily testFamily = SignificanceTestFamily.Parametric)
     {
         var pyNumeric = numericSeries
             .Select(s => (s.Name, (IReadOnlyDictionary<string, double>)s.Values.AsReadOnly()))
@@ -43,13 +45,17 @@ public class SignificancePlotService
             .ToList();
 
         var themeStr = theme == ThemeName.LightMode ? "light" : "dark";
+        var testFamilyStr = testFamily == SignificanceTestFamily.Nonparametric
+            ? "nonparametric"
+            : "parametric";
 
         var result = _module.CreateSignificanceMatrix(
             (figSize.Width, figSize.Height),
             pyNumeric,
             pyCategorical,
             themeStr,
-            dotSize);
+            dotSize,
+            testFamilyStr);
 
         string svgContent = result.Item2;
         var pointDataList = result.Item3;
@@ -58,6 +64,9 @@ public class SignificancePlotService
         foreach (var pointPyObj in pointDataList)
         {
             var d = pointPyObj.As<IReadOnlyDictionary<string, PyObject>>();
+            // p_value arrives as NaN when the cell was untestable (<2 valid
+            // groups / zero-variance group) — map that back to a null PValue.
+            var pValueRaw = d["p_value"].As<double>();
             dataPoints.Add(new SignificanceDataPoint(
                 CellRow: d["cell_row"].As<int>(),
                 CellCol: d["cell_col"].As<int>(),
@@ -69,7 +78,10 @@ public class SignificancePlotService
                 Mean: d["mean"].As<double>(),
                 Sem: d["sem"].As<double>(),
                 N: d["n"].As<int>(),
-                Color: d["color"].As<string>()));
+                Color: d["color"].As<string>(),
+                PValue: double.IsNaN(pValueRaw) ? null : pValueRaw,
+                TestFamily: testFamily,
+                Excluded: d["excluded"].As<bool>()));
         }
 
         return (svgContent, dataPoints);

--- a/Dotsesses/Services/StateService.cs
+++ b/Dotsesses/Services/StateService.cs
@@ -35,7 +35,8 @@ public class StateService
         IEnumerable<StudentAssessment> students,
         GradingSession gradingSession,
         IEnumerable<ScoreSelection> selections,
-        string? sourceFile = null)
+        string? sourceFile = null,
+        SignificanceTestFamily significanceTestFamily = SignificanceTestFamily.Parametric)
     {
         ArgumentNullException.ThrowIfNull(gradingSession);
 
@@ -60,9 +61,10 @@ public class StateService
 
         var state = new SavedState
         {
-            Version = 4,
+            Version = 5,
             SavedAt = DateTime.UtcNow,
             SourceFile = sourceFile,
+            SignificanceTestFamily = significanceTestFamily,
             Students = students.Select(s => new SavedStudent
             {
                 Id = s.Id,

--- a/Dotsesses/UI/MainWindow.axaml.cs
+++ b/Dotsesses/UI/MainWindow.axaml.cs
@@ -343,6 +343,21 @@ public partial class MainWindow : Window
                 return;
             }
 
+            // Get the SignificancePlotControl instance
+            var significancePlotControl = this.FindControl<SignificancePlotControl>("SignificancePlotControl")
+                                          ?? this.GetVisualDescendants().OfType<SignificancePlotControl>().FirstOrDefault();
+
+            if (significancePlotControl == null)
+            {
+                var errorBox = MessageBoxManager.GetMessageBoxStandard(
+                    "Export Error",
+                    "Could not find SignificancePlot control.",
+                    ButtonEnum.Ok,
+                    MsBoxIcon.Error);
+                await errorBox.ShowWindowDialogAsync(this);
+                return;
+            }
+
             // Get the PlotTabContainerViewModel for tab switching
             if (vm.PlotTabContainerViewModel == null)
             {
@@ -365,6 +380,7 @@ public partial class MainWindow : Window
                 DotPlotBorder,
                 violinPlotControl,
                 correlationPlotControl,
+                significancePlotControl,
                 vm.PlotTabContainerViewModel,
                 vm.ComplianceGrid?.Rows ?? Enumerable.Empty<Dotsesses.UI.ComplianceRowViewModel>(),
                 vm.Messenger,

--- a/Dotsesses/UI/MainWindow.axaml.cs
+++ b/Dotsesses/UI/MainWindow.axaml.cs
@@ -128,8 +128,9 @@ public partial class MainWindow : Window
 
     private void OnGlobalPointerMoved(object? sender, PointerEventArgs e)
     {
-        // Get service if not already cached
-        _hoverDelayService ??= App.Services?.GetService<HoverDelayService>();
+        // Window-scoped instance (cached in OnDataContextChanged); fall back to
+        // resolving from the VM if a pointer event somehow precedes it.
+        _hoverDelayService ??= (DataContext as MainWindowViewModel)?.HoverDelayService;
 
         if (_hoverDelayService != null)
         {
@@ -228,8 +229,9 @@ public partial class MainWindow : Window
     {
         if (DataContext is not MainWindowViewModel vm) return;
 
-        // Initialize hover delay service if needed
-        _hoverDelayService ??= App.Services?.GetService<HoverDelayService>();
+        // Window-scoped instance (cached in OnDataContextChanged); fall back to
+        // resolving from the VM so export gating acts on the plots' instance.
+        _hoverDelayService ??= vm.HoverDelayService;
 
         // Check if a student is currently selected
         if (vm.HoveredStudentId.HasValue)
@@ -560,8 +562,9 @@ public partial class MainWindow : Window
 
     private void OnDotPlotPointerMoved(object? sender, PointerEventArgs e)
     {
-        // Get service if not already cached
-        _hoverDelayService ??= App.Services?.GetService<HoverDelayService>();
+        // Window-scoped instance (cached in OnDataContextChanged); fall back to
+        // resolving from the VM if a pointer event somehow precedes it.
+        _hoverDelayService ??= (DataContext as MainWindowViewModel)?.HoverDelayService;
 
         if (_hoverDelayService != null)
         {
@@ -574,6 +577,14 @@ public partial class MainWindow : Window
     private void OnDataContextChanged(object? sender, EventArgs e)
     {
         if (DataContext is not MainWindowViewModel vm) return;
+
+        // Use the window's scoped HoverDelayService — the same instance the
+        // plot VMs hold — so export gating (IsExporting) and ClearHover act on
+        // the hover state the plots actually consult. Resolving from
+        // App.Services would hand back the root-scope orphan instead, leaving
+        // hover live during export (and breaking velocity tracking). See
+        // ADR-0012 (per-window scope).
+        _hoverDelayService = vm.HoverDelayService;
 
         vm.PropertyChanged += OnViewModelPropertyChanged;
 

--- a/Dotsesses/UI/MainWindowViewModel.cs
+++ b/Dotsesses/UI/MainWindowViewModel.cs
@@ -1329,7 +1329,8 @@ public partial class MainWindowViewModel : ViewModelBase
                 ClassAssessment.Assessments,
                 GradingSession,
                 ClassAssessment.ScoreSelections,
-                _currentSourceFile);
+                _currentSourceFile,
+                SignificancePlotViewModel?.TestFamily ?? SignificanceTestFamily.Parametric);
 
             CurrentSaveFilePath = filePath;
             HasUnsavedChanges = false;
@@ -1409,6 +1410,14 @@ public partial class MainWindowViewModel : ViewModelBase
         try
         {
             var state = await _stateService.LoadAsync(filePath);
+
+            // Restore the Significance Matrix test family before the matrix is
+            // (re)initialized below, so the first render uses the saved family.
+            // v4 files default to Parametric via SavedState's field default.
+            if (SignificancePlotViewModel != null)
+            {
+                SignificancePlotViewModel.TestFamily = state.SignificanceTestFamily;
+            }
 
             // Convert saved students back to domain models
             var (students, muppetMap) = _stateService.ConvertToStudents(state);

--- a/Dotsesses/UI/SignificancePlotControl.axaml
+++ b/Dotsesses/UI/SignificancePlotControl.axaml
@@ -16,5 +16,21 @@
             <!-- Per-dot interactive overlay (one Ellipse per data point with a ToolTip) -->
             <Canvas x:Name="PointsOverlay" Background="Transparent" />
         </Grid>
+
+        <!-- Controls overlay (top-right): per-cell test family selector. The
+             matrix p-values are RAW / exploratory-screening (see ADR-0014). -->
+        <ComboBox x:Name="TestFamilyCombo"
+                  HorizontalAlignment="Right"
+                  VerticalAlignment="Top"
+                  Margin="0,0,8,0"
+                  MinWidth="0"
+                  FontSize="11"
+                  SelectedIndex="0"
+                  Opacity="0.9"
+                  SelectionChanged="OnTestFamilyChanged"
+                  ToolTip.Tip="Per-cell omnibus test. Parametric = Welch's ANOVA (reduces to Welch's t for 2 groups); Non-parametric = Kruskal–Wallis (reduces to Mann–Whitney). p-values are uncorrected — this is an exploratory screening view.">
+            <ComboBoxItem>Parametric</ComboBoxItem>
+            <ComboBoxItem>Non-parametric</ComboBoxItem>
+        </ComboBox>
     </Grid>
 </UserControl>

--- a/Dotsesses/UI/SignificancePlotControl.axaml.cs
+++ b/Dotsesses/UI/SignificancePlotControl.axaml.cs
@@ -89,6 +89,7 @@ public partial class SignificancePlotControl : UserControl
             }
 
             vm.PropertyChanged += OnViewModelPropertyChanged;
+            SyncTestFamilySelection(vm);
             if (!string.IsNullOrEmpty(vm.SvgContent))
             {
                 UpdateSvgDisplay(vm.SvgContent);
@@ -96,10 +97,51 @@ public partial class SignificancePlotControl : UserControl
         }
     }
 
+    /// <summary>
+    /// Reflects the VM's <see cref="SignificancePlotViewModel.TestFamily"/>
+    /// onto the combo box. Setting SelectedIndex re-enters
+    /// <see cref="OnTestFamilyChanged"/>, but that handler no-ops when the
+    /// chosen family already matches the VM, so this won't loop or regenerate.
+    /// </summary>
+    private void SyncTestFamilySelection(SignificancePlotViewModel vm)
+    {
+        TestFamilyCombo.SelectedIndex =
+            vm.TestFamily == SignificanceTestFamily.Nonparametric ? 1 : 0;
+    }
+
+    /// <summary>
+    /// User picked a test family. Updates the VM and regenerates the plot in
+    /// the current theme. No-ops when the selection already matches the VM
+    /// (e.g. when the combo is being synced from the VM on load).
+    /// </summary>
+    private void OnTestFamilyChanged(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (DataContext is not SignificancePlotViewModel vm) return;
+
+        var family = TestFamilyCombo.SelectedIndex == 1
+            ? SignificanceTestFamily.Nonparametric
+            : SignificanceTestFamily.Parametric;
+        if (vm.TestFamily == family) return;
+
+        vm.TestFamily = family;
+
+        var b = SignificancePlotArea.Bounds;
+        if (b.Width > 0 && b.Height > 0 && !string.IsNullOrEmpty(vm.SvgContent))
+        {
+            vm.RegeneratePlot(b.Width, b.Height, _currentTheme);
+        }
+    }
+
     private void OnRenderWithThemeMessage(object recipient, RenderWithThemeMessage message)
     {
         _currentTheme = message.Theme;
         Background = ThemeColors.BackgroundBrush(_currentTheme);
+
+        // Hide the test-family combo while rendering for export / clipboard
+        // (the only path that switches to LightMode) so the interactive chrome
+        // doesn't bleed into the captured image; restore it on the DarkMode
+        // switch that follows.
+        TestFamilyCombo.IsVisible = message.Theme == ThemeName.DarkMode;
 
         Dispatcher.UIThread.Post(() =>
         {
@@ -125,6 +167,12 @@ public partial class SignificancePlotControl : UserControl
         if (e.PropertyName == nameof(SignificancePlotViewModel.SvgContent))
         {
             UpdateSvgDisplay(vm.SvgContent);
+        }
+        else if (e.PropertyName == nameof(SignificancePlotViewModel.TestFamily))
+        {
+            // Keep the combo in step when the family is restored from a loaded
+            // workspace (SavedState v5).
+            SyncTestFamilySelection(vm);
         }
     }
 

--- a/Dotsesses/UI/SignificancePlotViewModel.cs
+++ b/Dotsesses/UI/SignificancePlotViewModel.cs
@@ -38,6 +38,14 @@ public partial class SignificancePlotViewModel : ViewModelBase
     private string? _svgContent;
 
     /// <summary>
+    /// The omnibus test family applied per cell (see ADR-0014 slice 4).
+    /// Bound to the top-of-plot radio; the control regenerates on change.
+    /// Persisted with the workspace (SavedState v5).
+    /// </summary>
+    [ObservableProperty]
+    private SignificanceTestFamily _testFamily = SignificanceTestFamily.Parametric;
+
+    /// <summary>
     /// Scoped messenger for this VM's workspace (see ADR-0012). Exposed for
     /// the View code-behind even though Significance has no cross-view sync —
     /// keeping the symmetric shape lets future features (e.g. theme-render
@@ -75,7 +83,8 @@ public partial class SignificancePlotViewModel : ViewModelBase
             numericSeries,
             categoricalSeries,
             dotSize,
-            theme);
+            theme,
+            TestFamily);
 
         SvgContent = svgContent;
         _dataPoints = dataPoints;
@@ -135,16 +144,38 @@ public partial class SignificancePlotViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// Builds the per-dot tooltip text. N=1 collapses to mean only (SEM undefined).
+    /// Builds the per-dot tooltip text. N=1 collapses to mean only (SEM
+    /// undefined). The cell's omnibus test result is appended (slice 4): the
+    /// p-value + test name, or a note that the cell/subgroup couldn't be
+    /// tested. The p-value is a cell property, so every dot in the cell shows
+    /// the same value.
     /// </summary>
     public static string BuildTooltip(SignificanceDataPoint p)
     {
-        if (p.N <= 1)
+        var head = p.N <= 1
+            ? $"{p.CategoricalColumn} = {p.Subgroup}   (N = {p.N})\n" +
+              $"{p.NumericColumn}: {p.Mean:0.##}"
+            : $"{p.CategoricalColumn} = {p.Subgroup}   (N = {p.N})\n" +
+              $"{p.NumericColumn}: mean {p.Mean:0.##} ± {p.Sem:0.##} (SEM)";
+
+        var testName = p.TestFamily == SignificanceTestFamily.Nonparametric
+            ? "Kruskal–Wallis"
+            : "Welch ANOVA";
+
+        string statLine;
+        if (p.Excluded)
         {
-            return $"{p.CategoricalColumn} = {p.Subgroup}   (N = {p.N})\n" +
-                   $"{p.NumericColumn}: {p.Mean:0.##}";
+            statLine = $"excluded from test: N < 2";
         }
-        return $"{p.CategoricalColumn} = {p.Subgroup}   (N = {p.N})\n" +
-               $"{p.NumericColumn}: mean {p.Mean:0.##} ± {p.Sem:0.##} (SEM)";
+        else if (p.PValue is null)
+        {
+            statLine = $"{testName}: not testable (< 2 groups with N ≥ 2)";
+        }
+        else
+        {
+            statLine = $"{testName}: p = {p.PValue.Value:0.###}";
+        }
+
+        return head + "\n" + statLine;
     }
 }

--- a/SPEC.md
+++ b/SPEC.md
@@ -224,6 +224,28 @@ the average of this numeric column?*
   ```
 
   N=1 collapses to `Q1: 78.3 (N = 1)` (no ± since SEM is undefined).
+  The tooltip also carries the cell's test result line (see below) —
+  e.g. `Welch ANOVA: p = 0.003`, `Kruskal–Wallis: not testable
+  (< 2 groups with N ≥ 2)`, or `excluded from test: N < 2` on a dot
+  whose subgroup was dropped.
+- **Significance annotation** (top-right corner of each cell): the cell's
+  omnibus p-value plus tiered stars — `*` p<.05, `**` p<.01,
+  `***` p<.001. Significant cells render **bold** in a strong color;
+  non-significant cells render their p faint/grey with no star; cells that
+  can't be tested show an em-dash (`—`). Cells with no dots get no
+  annotation. p-values are **raw / uncorrected** — the matrix is an
+  exploratory screening view, not a confirmatory multiple-comparison
+  procedure.
+- **Test family selector** (top-right combo box): switches every cell between
+  *Parametric* (Welch's ANOVA — reduces to Welch's t for 2 subgroups) and
+  *Non-parametric* (Kruskal–Wallis — reduces to Mann–Whitney for 2). One
+  family is applied matrix-wide; the choice is **persisted** with the
+  workspace (SavedState v5; v4 files open as Parametric). The same family
+  handles categorical columns with 2 or 2+ values — no group-count
+  branching. Default: Parametric.
+- **Small-N test policy**: subgroups with N<2 are dropped from the test
+  (their dots still render); the cell is tested only if ≥2 valid subgroups
+  remain, otherwise the annotation is `—`.
 - **No cross-view sync** — the dots represent subgroups, not students,
   so hovering a matrix dot does not highlight anything in the dotplot
   or violin, and vice versa.
@@ -235,8 +257,9 @@ the average of this numeric column?*
   has Significance=false, the tab renders the empty-state hint
   "No Significant rows or columns to plot."
 
-A future revision will overlay a per-cell inferential test (Welch's
-ANOVA or Kruskal–Wallis) — see ADR-0014.
+A future revision may add an **effect-size** measure (η²/ε²) alongside the
+p-value so cells convey *magnitude*, not just detectability — see
+ADR-0015.
 
 ## Curve Compliance
 
@@ -374,7 +397,13 @@ single combined dialog lists each one. The categories it flags:
 
 - **Excel** export with columns for Student Id, AggregateScore, individual
   Scores, StudentAttributes, and assigned letter Grade.
-- **PowerPoint** export of the current plots.
+- **PowerPoint** export — one slide each for the dotplot, violin plot,
+  correlation matrix, and significance matrix, plus a grade-breakdown
+  table. Plots render in the light theme (dark text on white) while the
+  bright `CYCLING_PALETTE` dot colors are preserved. The significance
+  slide carries a footer documenting the per-cell test used (Welch's
+  ANOVA / Kruskal–Wallis), the star tiers, and that the p-values are raw
+  (exploratory).
 - **Copy plot** to clipboard for individual plots.
 
 ## Snapshot mode (for automated UI verification)

--- a/docs/adr/0015-significance-matrix-inferential-layer.md
+++ b/docs/adr/0015-significance-matrix-inferential-layer.md
@@ -1,0 +1,118 @@
+# Significance Matrix inferential layer (Welch ANOVA / Kruskal–Wallis)
+
+ADR-0014 shipped the descriptive Significance Matrix (mean ± SEM dots per
+Subgroup) and explicitly deferred the **inferential** layer — a per-cell
+statistical test — leaving the test choice open ("Welch's ANOVA or
+Kruskal–Wallis, TBD; … decision deferred to that slice"). This ADR makes
+that decision.
+
+Each cell now runs **one omnibus test** over its Subgroups and annotates
+the cell with the resulting p-value and tiered significance stars
+(`*` p<.05, `**` p<.01, `***` p<.001). A top-of-plot radio switches the
+whole matrix between two **Test Families**:
+
+- **Parametric — Welch's ANOVA** (default). Unequal-variance-safe;
+  reduces exactly to Welch's two-sided t-test for 2 groups (F = t²).
+- **Non-parametric — Kruskal–Wallis**. Rank-based; reduces to the
+  Mann–Whitney U test for 2 groups.
+
+## Why an omnibus test instead of branching on group count
+
+The user's framing ("some categories have 2 values, others have more, I
+assume there are multiple ways to do this") suggests a per-cell branch on
+the number of Subgroups. There is no need: an omnibus test answers the
+matrix's own question — *"does subgroup membership shift this mean,
+anywhere?"* — for any group count ≥ 2, and each family reduces to its
+two-group special case automatically. One code path covers a 2-value
+`Hat` column and a 4-value `Section` column identically.
+
+## Why Welch / Kruskal rather than classic ANOVA / t-test
+
+Grade subgroups are routinely unequal in size and variance and often
+non-normal. Classic one-way ANOVA assumes equal variances; Welch's does
+not, and is the modern default for real-world group comparisons.
+Kruskal–Wallis is the rank-based companion for users who distrust the
+parametric assumptions. Offering both as a radio honors the user's
+"switch between reasonable metrics" request while keeping the choice to a
+single, meaningful axis.
+
+scipy has **no built-in Welch ANOVA** (`scipy.stats.f_oneway` assumes
+equal variance), so the Welch F is computed by hand from the closed form
+(Welch 1951). This avoids adding a `pingouin`/`statsmodels` dependency for
+~15 lines of arithmetic; `scipy` (already a declared dependency) supplies
+`f.sf` for the p-value and `kruskal` for the non-parametric side. A
+verification check confirms the 2-group Welch ANOVA p equals
+`ttest_ind(equal_var=False)`.
+
+## Raw p-values — exploratory, not corrected
+
+A populated matrix runs many simultaneous tests, so ~1-in-20 cells will
+read "significant" by chance at α=.05. We deliberately show **raw,
+uncorrected** p-values and frame the matrix as an *exploratory screening*
+view (documented in SPEC and surfaced in tooltips), rather than applying
+FDR/Bonferroni. This matches how tools like GraphPad Prism present a grid
+of comparisons and keeps the stars stable as columns are added/removed.
+Correction can be layered in later as an opt-in without restructuring.
+
+## Marker design
+
+The p-value + stars print in each cell's top-right corner. Significant
+cells render bold in a strong (theme-aware) color; non-significant cells
+print their p faint/grey with no star; untestable cells show an em-dash
+(`—`). Every cell carries a value (no blank cells), which removes the
+"did the test run, or was it just not significant?" ambiguity while the
+bold/faint contrast still draws the eye to real hits. Tiers are the fixed
+universal convention (.05/.01/.001) — no adjustable α.
+
+## Small-N policy
+
+Welch's ANOVA needs within-group variance (each group N ≥ 2) and ≥ 2
+groups; Kruskal needs ≥ 2 groups. Subgroups with N < 2 are **dropped from
+the test** but their dots still render (they remain descriptively real);
+the dropped dot's tooltip says so. If fewer than 2 valid groups remain
+(or a parametric group has zero variance), the cell is untestable and
+shows `—`.
+
+## Persistence: SavedState v4 → v5
+
+The chosen Test Family persists with the workspace. `SavedState.Version`
+bumps 4 → 5; the new `SignificanceTestFamily` field defaults to
+`Parametric`, so v4 files silently migrate (the ADR-0002
+first-save-rewrites pattern, as with the v3 → v4 `Significance` flag).
+This is the third version bump in this feature area and was chosen over a
+session-only toggle (the precedent set by the Correlation diagonal toggle)
+because the test family is an analytic decision the user will want to
+survive a reload.
+
+## Data path
+
+`SignificanceDataPoint` gains the `PValue` (nullable; null when
+untestable), `TestFamily`, and `Excluded` fields ADR-0014 reserved. The
+Python point dict gains `p_value` (NaN ⇒ untestable), `test_family`, and
+`excluded`. The cell-level p is repeated on every dot in the cell (dots
+are the only things C# hit-tests), which the tooltip then surfaces.
+
+## Considered alternatives
+
+- **Branch per cell on group count** (t-test for 2, ANOVA for 3+).
+  Rejected — the omnibus reduction makes this redundant complexity.
+- **Classic equal-variance ANOVA.** Rejected — fragile for uneven grade
+  subgroups.
+- **FDR/Bonferroni correction now.** Deferred — adds a concept for a
+  non-statistician user and makes stars shift as the matrix resizes;
+  exploratory framing is honest and simpler.
+- **Adjustable α.** Rejected — the tiered stars already encode the
+  conventional cutoffs; an α control is extra UI/state for little gain.
+- **Effect size in this slice.** Deferred to a future revision — keeps
+  cells uncluttered; η²/ε² is the natural next enhancement.
+- **Session-only toggle** (no persistence). Rejected — the family is a
+  decision worth saving.
+
+## Consequences
+
+- `SavedState` v4 → v5; old files silent-migrate to Parametric.
+- The Significance tab gains a top-right test-family radio (mirrors the
+  Correlation tab's top-right control pattern).
+- `scipy` is now exercised at runtime (previously only declared); the
+  Welch F closed form lives in `significance_matrix.py`.
+- A future slice will add an effect-size measure (η²/ε²) — see SPEC.


### PR DESCRIPTION
## Summary

Completes the Significance Matrix **inferential layer** (ADR-0014's deferred "slice 4"), adds its **PowerPoint export**, and fixes a **hover/DI-scope bug** surfaced during export.

### Significance inferential layer (ADR-0015)
- Per-cell omnibus test annotated with p-value + tiered stars (`*` p<.05, `**` p<.01, `***` p<.001). Significant cells bold; non-significant faint; untestable cells show `—`.
- Top-of-plot selector toggles **Welch's ANOVA** (parametric; reduces to Welch's t for 2 groups) ⇄ **Kruskal–Wallis** (non-parametric; reduces to Mann–Whitney). One code path covers 2 and 2+ value categoricals. Welch's F computed by hand (scipy has no built-in); no new dependency.
- Small-N: subgroups with N<2 dropped from the test (dots still render); a cell with <2 valid groups is untestable.
- Raw, uncorrected p-values — exploratory-screening framing.
- Test family **persists**: `SavedState` v4 → v5 (silent migration to Parametric for old files).

### PowerPoint export
- New significance slide in the deck; footer documents the per-cell test used + star legend + exploratory note.
- The test-family combo is hidden during the light-theme export render so chrome doesn't bleed into the slide.

### Hover scope fix
- `MainWindow` resolved `HoverDelayService` from the **root** provider while the plot VMs use the **window-scoped** instance (`AddScoped`, ADR-0012) — different objects. So export's `IsExporting` and the dialog's `ClearHover()` acted on an orphan, and hover re-selected students during report generation.
- View now sources `vm.HoverDelayService`. Also fixes the dialog's "Clear selection" (was a no-op) and reactivates velocity-based hover delay (200–2000ms).

## Docs
ADR-0015 (new), CONTEXT.md, SPEC.md.

## Tests
236/236 pass (3 new persistence tests: v5 round-trip, test-family round-trip, v4→Parametric migration). Stats math verified against scipy (Welch(2)==`ttest_ind(equal_var=False)`).

## Verification
- [ ] Manual smoke test (owner): open Significance tab; confirm stars + faint/bold p; flip the selector and watch p-values change; export and check slide 4 (bright dots, legible stars, correct footer, no combo); hover a student → export → "Clear selection" clears drill-down; wave mouse over dots during generation → no re-selection.