### PR TITLE
fix(scores): type detection ignores trailer rows without a numeric Id

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,8 +28,10 @@ MuppetName.
 **StudentAttribute**: A non-numeric piece of Student data, e.g.
 `Submitted Outline = "Yes"` or `Mid-Term = "✔✔+"`. Categorical. May
 originate from auto-detection at load time (any non-numeric, non-empty
-cell in a column flips the entire column to a StudentAttribute) or, in
-slice 2, from a user converting a numeric Score column to Categorical
+cell *in a Student data row* — a row with a numeric Id — flips the
+entire column to a StudentAttribute; trailer rows such as summary
+statistics or a repeated header row are ignored for this decision) or,
+in slice 2, from a user converting a numeric Score column to Categorical
 in the Settings dialog. StudentAttributes appear in the Drill-down
 panel's Attributes list and as the *columns* of the
 **Significance Matrix**, but do not contribute to AggregateScore and

--- a/Dotsesses.Tests/Services/ScoreReaderTests.cs
+++ b/Dotsesses.Tests/Services/ScoreReaderTests.cs
@@ -407,6 +407,61 @@ public class ScoreReaderTests : IDisposable
             w.Kind == ReadWarningKind.CategoricalColumnDetected && w.Message.Contains("Mid-Term"));
     }
 
+    [Fact]
+    public void Read_TrailerRowsWithoutNumericId_DoNotFlipNumericColumns()
+    {
+        // Real spreadsheets carry trailer rows below the roster: summary stats
+        // ("AVG") and a repeated header row whose cells hold the column names as
+        // text ("Midterm"). Those rows have no numeric Id, so the row loop
+        // discards them — and type detection must ignore them too. Otherwise the
+        // literal "Midterm" in the repeated-header row flips the Midterm column
+        // to Categorical even though every actual student's Midterm is numeric.
+        var path = WriteFixture(s =>
+        {
+            s.Cell("A1").Value = "ID";
+            s.Cell("B1").Value = "Midterm";
+            s.Cell("C1").Value = "Total";
+            s.Cell("A2").Value = 1; s.Cell("B2").Value = 80; s.Cell("C2").Value = 80;
+            s.Cell("A3").Value = 2; s.Cell("B3").Value = 70; s.Cell("C3").Value = 70;
+            // Trailer rows (no numeric Id):
+            s.Cell("A5").Value = "AVG";     s.Cell("B5").Value = 75; s.Cell("C5").Value = 75;
+            s.Cell("A6").Value = "Midterm"; s.Cell("B6").Value = "Midterm"; s.Cell("C6").Value = "Total";
+        });
+
+        var result = new ScoreReader().Read(path);
+
+        // Two real students; Midterm stayed numeric (in Scores, not Attributes).
+        Assert.Equal(2, result.Students.Count);
+        Assert.All(result.Students, st => Assert.Empty(st.Attributes));
+        Assert.Contains(result.Students[0].Scores, sc => sc.Name == "Midterm" && sc.Value == 80);
+        Assert.DoesNotContain(result.Warnings, w =>
+            w.Kind == ReadWarningKind.CategoricalColumnDetected);
+    }
+
+    [Fact]
+    public void Read_TrailerRows_DoNotMaskGenuinelyCategoricalColumns()
+    {
+        // The valid-Id gate must not over-correct: a column that is non-numeric
+        // in a real student row is still Categorical, trailer rows notwithstanding.
+        var path = WriteFixture(s =>
+        {
+            s.Cell("A1").Value = "ID";
+            s.Cell("B1").Value = "Submitted Outline";
+            s.Cell("C1").Value = "Total";
+            s.Cell("A2").Value = 1; s.Cell("B2").Value = "Yes"; s.Cell("C2").Value = 80;
+            s.Cell("A3").Value = 2; s.Cell("B3").Value = "No";  s.Cell("C3").Value = 70;
+            s.Cell("A5").Value = "AVG"; s.Cell("C5").Value = 75; // trailer
+        });
+
+        var result = new ScoreReader().Read(path);
+
+        Assert.Equal(2, result.Students.Count);
+        Assert.All(result.Students, st => Assert.Single(st.Attributes,
+            a => a.Name == "Submitted Outline"));
+        Assert.Contains(result.Warnings, w =>
+            w.Kind == ReadWarningKind.CategoricalColumnDetected && w.Message.Contains("Submitted Outline"));
+    }
+
     // ===== Hard errors =====
 
     [Fact]

--- a/Dotsesses/Services/ScoreReader.cs
+++ b/Dotsesses/Services/ScoreReader.cs
@@ -146,14 +146,18 @@ public class ScoreReader
         }
 
         // ===== Type-inference pre-scan =====
-        // A column is Categorical if any non-empty cell fails to parse as a double.
-        // The "is this cell empty?" decision MUST match the row loop below so that
-        // detection and population stay consistent.
+        // A column is Categorical if any non-empty cell IN A STUDENT DATA ROW
+        // fails to parse as a double. The row-eligibility decision (blank rows
+        // AND rows without a numeric Id) MUST match the row loop below so that
+        // detection and population stay consistent — otherwise non-numeric text
+        // in a trailer row (e.g. a repeated header row's "Q1") flips a column to
+        // Categorical even though the row loop discards that row.
         var categoricalColumns = new HashSet<int>();
         for (int r = 1; r < table.Rows.Count; r++)
         {
             var row = table.Rows[r];
             if (IsBlankRow(row)) continue;
+            if (!TryReadStudentId(row[0], out _)) continue;
             foreach (var (columnIndex, _) in scoreColumns)
             {
                 if (categoricalColumns.Contains(columnIndex)) continue;
@@ -206,13 +210,7 @@ public class ScoreReader
                 continue;
             }
 
-            var idValue = row[0];
-            int studentId;
-            if (idValue is double d)
-            {
-                studentId = (int)d;
-            }
-            else if (!int.TryParse(idValue?.ToString(), out studentId))
+            if (!TryReadStudentId(row[0], out int studentId))
             {
                 skippedRows++;
                 continue;
@@ -397,5 +395,25 @@ public class ScoreReader
             }
         }
         return true;
+    }
+
+    /// <summary>
+    /// A row is a Student data row only if its first cell holds a valid integer
+    /// Id. Shared by the type-inference pre-scan and the row-parsing loop so the
+    /// two agree on which rows count: trailer rows that real spreadsheets carry
+    /// below the roster — summary statistics ("AVG", "Stdev"), repeated header
+    /// rows, max-points rows — all lack a numeric Id and must be ignored by
+    /// BOTH. (Previously only the parser skipped them, so non-numeric text in a
+    /// repeated header row like "Q1" wrongly flipped the Q1 column to
+    /// Categorical.)
+    /// </summary>
+    private static bool TryReadStudentId(object? idValue, out int studentId)
+    {
+        if (idValue is double d)
+        {
+            studentId = (int)d;
+            return true;
+        }
+        return int.TryParse(idValue?.ToString(), out studentId);
     }
 }

--- a/docs/adr/0013-score-column-type-on-selection.md
+++ b/docs/adr/0013-score-column-type-on-selection.md
@@ -16,6 +16,16 @@ column to Categorical. Categorical columns produce a new
 `ReadWarningKind.CategoricalColumnDetected` warning so the user sees
 which columns were auto-classified.
 
+The type-inference pre-scan considers only **Student data rows** — rows
+whose first cell holds a numeric Id — using the same `TryReadStudentId`
+gate as the row-parsing loop. Trailer rows that real gradebooks carry
+below the roster (summary statistics like `AVG`/`Stdev`, repeated header
+rows whose cells echo the column names, max-points rows) lack a numeric
+Id and are skipped by both. Without this, the literal `"Q1"` in a
+repeated-header row would flip the `Q1` column to Categorical even
+though every actual student's `Q1` is numeric. Detection and population
+must apply the identical row-eligibility rule.
+
 Slice 2 (a follow-up branch) makes `Type` user-toggleable via a
 combobox column in the Settings dialog, with `Numeric ↔ Categorical`
 both supported. `Categorical → Numeric` is gated on every value


### PR DESCRIPTION
## Problem

Loading a real gradebook (`CP 2025-05.29.26 data.xlsx`) wrongly flipped numeric score columns (`Q1`, `Q2`, `Q3`, `Q4`, `MS`, `MC2`, `Class`, `Total`, …) to **Categorical**.

## Root cause

A consistency bug between two passes over the rows:

- The **row parser** only treats a row as a student when its first cell holds a numeric Id, so trailer rows are discarded.
- The **type pre-scan** only skipped *fully blank* rows — it scanned the trailer rows real gradebooks carry below the roster: summary statistics (`AVG`, `Stdev`), **repeated header rows** whose cells echo the column names (`Q1`, `Q2`, …), and max-points rows.

So the literal `"Q1"` text in a repeated-header row flipped the `Q1` column to Categorical, even though every actual student's `Q1` is numeric — and the parser then threw that very row away.

## Fix

Apply the same row-eligibility rule in both places via a shared `TryReadStudentId` gate. The pre-scan now considers only Student data rows (rows with a numeric Id). Classification depends solely on the presence of non-numeric values in **real student rows**, never on trailer content.

Verified against the reported file: only `Gender` (genuinely text in student rows) stays categorical; all score columns correctly stay numeric.

## Tests

Two regression tests (trailer rows no longer flip a numeric column; the gate doesn't mask a genuinely categorical column). 238/238 pass. Fixtures are built in-memory via ClosedXML per repo convention — no binary test data added.

Docs: CONTEXT.md, ADR-0013.