### PR TITLE
feat(violin): pin hover tooltips to top, staggered, when >10 series

### DIFF
--- a/Dotsesses/UI/ViolinPlotControl.axaml.cs
+++ b/Dotsesses/UI/ViolinPlotControl.axaml.cs
@@ -451,8 +451,17 @@ public partial class ViolinPlotControl : UserControl
             var displayWidth = plotBounds.Width > 0 ? plotBounds.Width : 800;
             var displayHeight = plotBounds.Height > 0 ? plotBounds.Height : 400;
 
-            foreach (var point in studentPoints)
+            // With many score series the per-dot tooltips crowd the plot, so
+            // pin them to a single row at the very top (still aligned to each
+            // series' column) once the displayed-series count exceeds the
+            // threshold. See SPEC "Distribution plot".
+            bool pinTooltipsToTop =
+                vm.GetAllPoints().Select(p => p.Series).Distinct().Count() > MaxSeriesForInlineTooltips;
+
+            for (int seriesIndex = 0; seriesIndex < studentPoints.Count; seriesIndex++)
             {
+                var point = studentPoints[seriesIndex];
+
                 // Find the shape for this student using actual display coordinates
                 var (displayX, displayY) = vm.SvgToDisplayWithSize(point.X, point.Y, displayWidth, displayHeight);
 
@@ -480,15 +489,13 @@ public partial class ViolinPlotControl : UserControl
                 }
 
                 // Create tooltip
-                CreateTooltip(point, displayX, displayY);
+                CreateTooltip(point, displayX, displayY, pinTooltipsToTop, seriesIndex);
 
                 // Create comment at top or bottom based on series index, centered on series X position
                 // Use live comment from ClassAssessment instead of cached point.Comment
                 var liveComment = vm.GetLiveComment(point.StudentId, point.Series);
                 if (!string.IsNullOrEmpty(liveComment))
                 {
-                    // Find series index to determine top vs bottom positioning
-                    var seriesIndex = studentPoints.IndexOf(point);
                     CreateSeriesComment(point, liveComment, displayX, displayHeight, seriesIndex);
                 }
             }
@@ -576,7 +583,17 @@ public partial class ViolinPlotControl : UserControl
         CommentsOverlay.Children.Add(commentBorder);
     }
 
-    private void CreateTooltip(ViolinDataPoint point, double displayX, double displayY)
+    // Above this many displayed score series, hover tooltips move from beside
+    // each dot to a single row pinned at the top of the plot (they crowd the
+    // dots otherwise).
+    private const int MaxSeriesForInlineTooltips = 10;
+    private const double TooltipTopMargin = 4;
+    private const double TooltipRowGap = 2;
+    // Odd-row tooltips drop a full tooltip height plus 25% so the two rows
+    // read with a clear gap rather than sitting flush.
+    private const double SecondRowHeightFactor = 1.25;
+
+    private void CreateTooltip(ViolinDataPoint point, double displayX, double displayY, bool pinToTop, int seriesIndex)
     {
         var tooltipBorder = new Border
         {
@@ -626,6 +643,7 @@ public partial class ViolinPlotControl : UserControl
         // Measure tooltip to determine positioning
         tooltipBorder.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
         double tooltipWidth = tooltipBorder.DesiredSize.Width;
+        double tooltipHeight = tooltipBorder.DesiredSize.Height;
 
         // Get canvas width
         double canvasWidth = TooltipsOverlay.Bounds.Width;
@@ -636,7 +654,17 @@ public partial class ViolinPlotControl : UserControl
             : displayX + 20;
 
         Canvas.SetLeft(tooltipBorder, leftPos);
-        Canvas.SetTop(tooltipBorder, displayY - 10);
+        // Many-series mode: pin to the top of the plot (still horizontally
+        // aligned to the series column) instead of floating beside the dot.
+        // Stagger odd series into a second row — offset down by a full tooltip
+        // height — so neighbouring top-row tooltips don't overlap horizontally.
+        double topPos = displayY - 10;
+        if (pinToTop)
+        {
+            double secondRowOffset = (seriesIndex % 2 == 1) ? tooltipHeight * SecondRowHeightFactor + TooltipRowGap : 0;
+            topPos = TooltipTopMargin + secondRowOffset;
+        }
+        Canvas.SetTop(tooltipBorder, topPos);
 
         TooltipsOverlay.Children.Add(tooltipBorder);
     }

--- a/SPEC.md
+++ b/SPEC.md
@@ -176,7 +176,13 @@ with swarm overlay.
 - One series per Score whose **Display** ScoreSelection flag is on.
 - Hollow square for any Score with a Comment; filled circle otherwise.
 - Hover: highlights the same Student in every series and in the
-  dotplot. Tooltip shows Score value and that Score's Comment.
+  dotplot. Tooltip shows Score value and that Score's Comment. Each
+  hovered Student gets one tooltip per series; these normally float
+  beside their dots, but when **more than 10** score series are shown
+  they crowd the dots, so they relocate to the very top of the plot
+  (each still horizontally aligned to its series column). Odd-indexed
+  series are staggered down by one tooltip height into a second row so
+  neighbouring tooltips stay legible.
 - Resize debounce: 300 ms before regenerating the Python plot.
 - Click / double-click / right-click — same comment-editor behavior as
   the dotplot.


### PR DESCRIPTION
## Summary

In the Distribution (violin) plot, hovering a student draws one tooltip per score series beside each dot. With many series the tooltips crowd the dots and overlap.

When **more than 10** score series are shown:
- Tooltips relocate to the **top** of the plot, each still horizontally aligned to its series column.
- **Odd-indexed** series are staggered down by **1.25× a tooltip height** into a second row, so neighbouring tooltips don't overlap and stay readable.

At ≤10 series, the prior beside-the-dot behavior is unchanged.

Also tidies the hover loop to a single indexed `for`, dropping the O(n²) `IndexOf` the comment placement used.

Docs: SPEC.md (Distribution/violin section).

## Verification

View/hover code — no unit-test seam. Manual: open the Distribution tab on a file with >10 numeric score columns, hover a student, confirm the tooltips form a two-row header at the top. 238/238 existing tests pass; build clean.