### PR TITLE
feat(selection): data-driven default column selection per plot

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -99,7 +99,10 @@ data lives in StudentAttributes and bypasses the violin / correlation /
 aggregate paths. Significance is meaningful for *both* Types — Numeric
 columns become Significance Matrix rows, Categorical columns become
 Significance Matrix columns. Persisted on ClassAssessment (see
-ADR-0013, ADR-0014).
+ADR-0013, ADR-0014). At fresh load the flags are seeded **data-driven**
+per plot rather than all-on — Total + 10 leftmost for Display, the
+top-r² pairs + Total for Correlation, and qualifying categoricals with
+their strongest numerics for Significance (see ADR-0016).
 
 **ClassAssessment**: The post-load dataset for one Class — the
 StudentAssessments, the GradeCurve in use, ScoreSelections,

--- a/Dotsesses.Tests/Calculators/PlotSelectionCalculatorTests.cs
+++ b/Dotsesses.Tests/Calculators/PlotSelectionCalculatorTests.cs
@@ -1,0 +1,178 @@
+namespace Dotsesses.Tests.Calculators;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Dotsesses.Calculators;
+using Xunit;
+
+/// <summary>
+/// Covers the data-driven default plot selection rules (ADR-0016):
+/// distribution = Total + 10 leftmost numerics; correlation = top-r²
+/// non-Total pairs' union + Total; significance = qualifying categoricals
+/// (min p ≤ 0.2) + their top-3 smallest-p numerics.
+/// </summary>
+public class PlotSelectionCalculatorTests
+{
+    private static IReadOnlyDictionary<string, double> Series(params double[] values)
+    {
+        var d = new Dictionary<string, double>();
+        for (int i = 0; i < values.Length; i++) d[$"S{i:D3}"] = values[i];
+        return d;
+    }
+
+    // ===== Distribution =====
+
+    [Fact]
+    public void SelectDistribution_TakesTotalPlusFirstTen()
+    {
+        var names = new[] { "Total", "Q1", "Q2", "Q3", "Q4", "Q5", "Q6", "Q7", "Q8", "Q9", "Q10", "Q11", "Q12" };
+        var result = PlotSelectionCalculator.SelectDistribution(names, "Total");
+
+        Assert.Contains("Total", result);
+        Assert.Equal(11, result.Count); // Total + first 10 non-Total
+        for (int i = 1; i <= 10; i++) Assert.Contains($"Q{i}", result);
+        Assert.DoesNotContain("Q11", result);
+        Assert.DoesNotContain("Q12", result);
+    }
+
+    [Fact]
+    public void SelectDistribution_FewerThanTen_TakesAll()
+    {
+        var names = new[] { "Total", "Q1", "Q2", "Q3" };
+        var result = PlotSelectionCalculator.SelectDistribution(names, "Total");
+        Assert.Equal(new HashSet<string> { "Total", "Q1", "Q2", "Q3" }, result);
+    }
+
+    [Fact]
+    public void SelectDistribution_NoTotal_TakesFirstTen()
+    {
+        var names = Enumerable.Range(1, 15).Select(i => $"Q{i}").ToList();
+        var result = PlotSelectionCalculator.SelectDistribution(names, totalName: null);
+        Assert.Equal(10, result.Count);
+        Assert.Contains("Q1", result);
+        Assert.Contains("Q10", result);
+        Assert.DoesNotContain("Q11", result);
+    }
+
+    // ===== Pearson r² =====
+
+    [Fact]
+    public void PearsonR2_PerfectLinear_IsOne()
+    {
+        var a = Series(1, 2, 3, 4, 5);
+        var b = Series(2, 4, 6, 8, 10);   // b = 2a
+        Assert.Equal(1.0, PlotSelectionCalculator.PearsonR2(a, b)!.Value, 6);
+    }
+
+    [Fact]
+    public void PearsonR2_PerfectInverse_IsOne()
+    {
+        var a = Series(1, 2, 3, 4, 5);
+        var b = Series(5, 4, 3, 2, 1);    // r = -1 → r² = 1
+        Assert.Equal(1.0, PlotSelectionCalculator.PearsonR2(a, b)!.Value, 6);
+    }
+
+    [Fact]
+    public void PearsonR2_KnownValue()
+    {
+        // x=[1,2,3], y=[1,3,2] → r = 0.5 → r² = 0.25 (hand-computed).
+        var x = Series(1, 2, 3);
+        var y = Series(1, 3, 2);
+        Assert.Equal(0.25, PlotSelectionCalculator.PearsonR2(x, y)!.Value, 6);
+    }
+
+    [Fact]
+    public void PearsonR2_ZeroVarianceOrTooFewCommon_IsNull()
+    {
+        Assert.Null(PlotSelectionCalculator.PearsonR2(Series(1, 1, 1), Series(2, 3, 4))); // flat x
+        Assert.Null(PlotSelectionCalculator.PearsonR2(
+            new Dictionary<string, double> { ["S000"] = 1 },
+            new Dictionary<string, double> { ["S000"] = 2 }));                            // <2 common
+    }
+
+    // ===== Correlation =====
+
+    [Fact]
+    public void SelectCorrelation_PicksTopPairColumns_PlusTotal_ExcludesLowCorrelates()
+    {
+        // A=B=C=D are identical → every pair among them has r²=1, so the top-4
+        // pairs are all within {A,B,C,D}; E and F are noise and never make the
+        // cut. Total is excluded from ranking but always added.
+        var lin = new double[] { 1, 2, 3, 4, 5, 6 };
+        var series = new List<(string, IReadOnlyDictionary<string, double>)>
+        {
+            ("A", Series(lin)),
+            ("B", Series(lin)),
+            ("C", Series(lin)),
+            ("D", Series(lin)),
+            ("E", Series(1, 1, 2, 2, 1, 1)),
+            ("F", Series(3, 1, 4, 1, 5, 2)),
+            ("Total", Series(2, 4, 6, 8, 10, 12)),
+        };
+
+        var result = PlotSelectionCalculator.SelectCorrelation(series, "Total");
+
+        Assert.Contains("Total", result);
+        foreach (var c in new[] { "A", "B", "C", "D" }) Assert.Contains(c, result);
+        Assert.DoesNotContain("E", result);
+        Assert.DoesNotContain("F", result);
+    }
+
+    // ===== Significance =====
+
+    [Fact]
+    public void SelectSignificance_QualifiersPlusTopThreeNumerics()
+    {
+        var numerics = new[] { "Q1", "Q2", "Q3", "Q4", "Q5" };
+        var cats = new[] { "Hat", "Section", "Gender" };
+        var p = new Dictionary<(string, string), double?>
+        {
+            // Hat qualifies (min .01); top-3 smallest = Q1, Q3, Q5
+            [("Q1", "Hat")] = 0.01, [("Q2", "Hat")] = 0.50, [("Q3", "Hat")] = 0.03,
+            [("Q4", "Hat")] = 0.80, [("Q5", "Hat")] = 0.15,
+            // Section: all > .2 → dropped
+            [("Q1", "Section")] = 0.30, [("Q2", "Section")] = 0.40, [("Q3", "Section")] = 0.55,
+            [("Q4", "Section")] = 0.99, [("Q5", "Section")] = 0.60,
+            // Gender qualifies at the .2 boundary (inclusive); top-3 = Q2, Q4, Q1
+            [("Q1", "Gender")] = 0.30, [("Q2", "Gender")] = 0.20, [("Q3", "Gender")] = null,
+            [("Q4", "Gender")] = 0.25, [("Q5", "Gender")] = 0.90,
+        };
+
+        var result = PlotSelectionCalculator.SelectSignificance(
+            numerics, cats, (n, c) => p.TryGetValue((n, c), out var v) ? v : null);
+
+        // Hat + its top-3
+        Assert.Contains("Hat", result);
+        Assert.Contains("Q1", result);
+        Assert.Contains("Q3", result);
+        Assert.Contains("Q5", result);
+        // Gender qualifies at exactly 0.2; its top-3 smallest are Q2, Q4, Q1
+        Assert.Contains("Gender", result);
+        Assert.Contains("Q2", result);
+        Assert.Contains("Q4", result);
+        // Section dropped (no cell ≤ 0.2)
+        Assert.DoesNotContain("Section", result);
+        // Q2-of-Hat (.5) is not in Hat's top-3, but Q2 is pulled in via Gender — fine.
+    }
+
+    [Fact]
+    public void SelectSignificance_NoQualifiers_IsEmpty()
+    {
+        var result = PlotSelectionCalculator.SelectSignificance(
+            new[] { "Q1", "Q2" },
+            new[] { "Hat" },
+            (_, _) => 0.9);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void SelectSignificance_AllUntestable_IsEmpty()
+    {
+        var result = PlotSelectionCalculator.SelectSignificance(
+            new[] { "Q1", "Q2" },
+            new[] { "Hat" },
+            (_, _) => null);
+        Assert.Empty(result);
+    }
+}

--- a/Dotsesses.Tests/ViewModels/MainWindowViewModelBuildSeriesDataTests.cs
+++ b/Dotsesses.Tests/ViewModels/MainWindowViewModelBuildSeriesDataTests.cs
@@ -27,10 +27,10 @@ public class MainWindowViewModelBuildSeriesDataTests
         var excluded = firstStudentScores.First();
         var excludedDisplayName = DisplayName(excluded);
 
+        // Normalize to all-Display-on, then flip just the excluded column off,
+        // so this exercises the filter independent of the data-driven defaults.
         var newSelections = vm.ClassAssessment.ScoreSelections
-            .Select(s => (s.Name == excluded.Name && s.Index == excluded.Index)
-                ? s with { Display = false }
-                : s)
+            .Select(s => s with { Display = !(s.Name == excluded.Name && s.Index == excluded.Index) })
             .ToList();
         vm.ClassAssessment.ScoreSelections = newSelections;
 
@@ -51,10 +51,10 @@ public class MainWindowViewModelBuildSeriesDataTests
         var excluded = firstStudentScores.Last();
         var excludedDisplayName = DisplayName(excluded);
 
+        // Normalize to all-Correlation-on, then flip just the excluded column
+        // off, so this exercises the filter independent of the data-driven defaults.
         var newSelections = vm.ClassAssessment.ScoreSelections
-            .Select(s => (s.Name == excluded.Name && s.Index == excluded.Index)
-                ? s with { Correlation = false }
-                : s)
+            .Select(s => s with { Correlation = !(s.Name == excluded.Name && s.Index == excluded.Index) })
             .ToList();
         vm.ClassAssessment.ScoreSelections = newSelections;
 
@@ -95,10 +95,10 @@ public class MainWindowViewModelBuildSeriesDataTests
         var excluded = firstStudentScores[0];
         var sampled = firstStudentScores[1];
 
+        // Normalize to all-Display-on, then flip just the excluded column off,
+        // so this exercises the filter independent of the data-driven defaults.
         var newSelections = vm.ClassAssessment.ScoreSelections
-            .Select(s => (s.Name == excluded.Name && s.Index == excluded.Index)
-                ? s with { Display = false }
-                : s)
+            .Select(s => s with { Display = !(s.Name == excluded.Name && s.Index == excluded.Index) })
             .ToList();
         vm.ClassAssessment.ScoreSelections = newSelections;
 

--- a/Dotsesses.Tests/ViewModels/MainWindowViewModelTests.cs
+++ b/Dotsesses.Tests/ViewModels/MainWindowViewModelTests.cs
@@ -150,32 +150,41 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
-    public void LoadFromExcelFile_SeedsDefaultSelections()
+    public void LoadFromExcelFile_SeedsDataDrivenDefaultSelections()
     {
         // Arrange / Act — CreateViewModel calls LoadFromExcelFile via the T01 factory.
+        // (CreateForTesting has no Python service, so the Significance refinement
+        //  is skipped; this asserts the pure Display/Correlation/Aggregate rules.
+        //  ADR-0016.)
         var vm = CreateViewModel();
 
-        // Assert
-        var firstStudentScores = vm.ClassAssessment.Assessments.First().Scores;
         var selections = vm.ClassAssessment.ScoreSelections;
-
+        var firstStudentScores = vm.ClassAssessment.Assessments.First().Scores;
         Assert.Equal(firstStudentScores.Count, selections.Count);
 
-        foreach (var sel in selections)
-        {
-            Assert.True(sel.Display, $"Display should default true for {sel.Name}");
-            Assert.True(sel.Correlation, $"Correlation should default true for {sel.Name}");
+        var numeric = selections.Where(s => s.Type == ScoreColumnType.Numeric).ToList();
+        var total = numeric.SingleOrDefault(s =>
+            string.Equals(s.Name, "Total", StringComparison.OrdinalIgnoreCase) && s.Index == null);
+        Assert.NotNull(total);
 
-            var isTotal = string.Equals(sel.Name, "Total", StringComparison.OrdinalIgnoreCase);
-            if (isTotal)
-            {
-                Assert.False(sel.Aggregate, "The 'Total' column must default to Aggregate=false.");
-            }
-            else
-            {
-                Assert.True(sel.Aggregate, $"Non-Total score {sel.Name} should default to Aggregate=true.");
-            }
-        }
+        // Distribution: Total + the first 10 non-Total numerics in column order.
+        var expectedDisplay = new HashSet<(string, int?)> { (total!.Name, total.Index) };
+        foreach (var s in numeric.Where(s => s != total).Take(10))
+            expectedDisplay.Add((s.Name, s.Index));
+        foreach (var sel in selections)
+            Assert.Equal(expectedDisplay.Contains((sel.Name, sel.Index)), sel.Display);
+
+        // Correlation: Total always in; pared to the top-4-pair union (≤ 9 columns).
+        Assert.True(total.Correlation, "Total must always be selected for Correlation.");
+        Assert.All(selections.Where(s => s.Correlation),
+            s => Assert.Equal(ScoreColumnType.Numeric, s.Type));
+        Assert.True(selections.Count(s => s.Correlation) <= 9,
+            "Correlation default is at most Total + the 4 top-r² pairs (≤ 9 columns).");
+
+        // Aggregate is unchanged by the data-driven selection.
+        Assert.False(total.Aggregate, "The 'Total' column must default to Aggregate=false.");
+        Assert.All(numeric.Where(s => s != total),
+            s => Assert.True(s.Aggregate, $"Non-Total score {s.Name} should default to Aggregate=true."));
     }
 
     [Fact]

--- a/Dotsesses/Calculators/PlotSelectionCalculator.cs
+++ b/Dotsesses/Calculators/PlotSelectionCalculator.cs
@@ -1,0 +1,167 @@
+namespace Dotsesses.Calculators;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+/// <summary>
+/// Computes the data-driven default column selection for each plot when a
+/// fresh dataset loads, so a 30–40-column gradebook doesn't open with every
+/// column on in every plot (see ADR-0016). Pure and deterministic — keyed by
+/// the same *series name* the plots join on, so the caller can apply results
+/// by recomputing each <c>ScoreSelection</c>'s series name.
+///
+/// The three rules:
+/// <list type="bullet">
+///   <item><b>Distribution</b>: Total + the first N non-Total numerics in
+///   column order.</item>
+///   <item><b>Correlation</b>: the columns appearing in the top-K highest-r²
+///   pairs (Total excluded from the ranking), plus Total.</item>
+///   <item><b>Significance</b>: categoricals whose smallest p across numerics
+///   is ≤ a threshold, each with its top-M smallest-p numerics, unioned.</item>
+/// </list>
+/// </summary>
+public static class PlotSelectionCalculator
+{
+    /// <summary>
+    /// Distribution (violin) selection: <paramref name="totalName"/> always,
+    /// then the first <paramref name="extra"/> non-Total numeric series in the
+    /// given (left-to-right column) order.
+    /// </summary>
+    public static HashSet<string> SelectDistribution(
+        IReadOnlyList<string> orderedNumericNames,
+        string? totalName,
+        int extra = 10)
+    {
+        ArgumentNullException.ThrowIfNull(orderedNumericNames);
+
+        var result = new HashSet<string>(StringComparer.Ordinal);
+        if (totalName != null) result.Add(totalName);
+
+        int added = 0;
+        foreach (var name in orderedNumericNames)
+        {
+            if (added >= extra) break;
+            if (totalName != null && string.Equals(name, totalName, StringComparison.Ordinal)) continue;
+            if (result.Add(name)) added++;
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Correlation selection: rank every pair of non-Total numeric series by
+    /// Pearson r², take the top <paramref name="topPairs"/>, select every
+    /// series appearing in them, and always include <paramref name="totalName"/>.
+    /// (Total is excluded from the ranking because it tracks its components and
+    /// would otherwise win every slot.)
+    /// </summary>
+    public static HashSet<string> SelectCorrelation(
+        IReadOnlyList<(string Name, IReadOnlyDictionary<string, double> Values)> numericSeries,
+        string? totalName,
+        int topPairs = 4)
+    {
+        ArgumentNullException.ThrowIfNull(numericSeries);
+
+        var result = new HashSet<string>(StringComparer.Ordinal);
+        if (totalName != null) result.Add(totalName);
+
+        var cols = numericSeries
+            .Where(s => totalName == null || !string.Equals(s.Name, totalName, StringComparison.Ordinal))
+            .ToList();
+
+        var pairs = new List<(string A, string B, double R2)>();
+        for (int i = 0; i < cols.Count; i++)
+        {
+            for (int j = i + 1; j < cols.Count; j++)
+            {
+                var r2 = PearsonR2(cols[i].Values, cols[j].Values);
+                if (r2.HasValue) pairs.Add((cols[i].Name, cols[j].Name, r2.Value));
+            }
+        }
+
+        foreach (var p in pairs
+                     .OrderByDescending(p => p.R2)
+                     .ThenBy(p => p.A, StringComparer.Ordinal)
+                     .ThenBy(p => p.B, StringComparer.Ordinal)
+                     .Take(topPairs))
+        {
+            result.Add(p.A);
+            result.Add(p.B);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Significance selection. <paramref name="pLookup"/> returns the omnibus
+    /// p-value for a (numeric, categorical) cell, or null when untestable. A
+    /// categorical *qualifies* if its smallest p across numerics is ≤
+    /// <paramref name="threshold"/>; for each qualifier the
+    /// <paramref name="topNumerics"/> numerics with the smallest p are added.
+    /// Returns the union of qualifying categoricals and their selected numerics.
+    /// </summary>
+    public static HashSet<string> SelectSignificance(
+        IReadOnlyList<string> numericNames,
+        IReadOnlyList<string> categoricalNames,
+        Func<string, string, double?> pLookup,
+        double threshold = 0.2,
+        int topNumerics = 3)
+    {
+        ArgumentNullException.ThrowIfNull(numericNames);
+        ArgumentNullException.ThrowIfNull(categoricalNames);
+        ArgumentNullException.ThrowIfNull(pLookup);
+
+        var result = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var cat in categoricalNames)
+        {
+            var ps = numericNames
+                .Select(n => (Name: n, P: pLookup(n, cat)))
+                .Where(t => t.P.HasValue)
+                .Select(t => (t.Name, P: t.P!.Value))
+                .ToList();
+            if (ps.Count == 0) continue;
+            if (ps.Min(t => t.P) > threshold) continue;
+
+            result.Add(cat);
+            foreach (var t in ps
+                         .OrderBy(t => t.P)
+                         .ThenBy(t => t.Name, StringComparer.Ordinal)
+                         .Take(topNumerics))
+            {
+                result.Add(t.Name);
+            }
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Pearson r² between two series over their common student ids. Returns
+    /// null when fewer than two ids overlap or either side has zero variance
+    /// (r undefined).
+    /// </summary>
+    public static double? PearsonR2(
+        IReadOnlyDictionary<string, double> a,
+        IReadOnlyDictionary<string, double> b)
+    {
+        ArgumentNullException.ThrowIfNull(a);
+        ArgumentNullException.ThrowIfNull(b);
+
+        double sx = 0, sy = 0, sxx = 0, syy = 0, sxy = 0;
+        int n = 0;
+        foreach (var kv in a)
+        {
+            if (!b.TryGetValue(kv.Key, out var y)) continue;
+            double x = kv.Value;
+            sx += x; sy += y; sxx += x * x; syy += y * y; sxy += x * y; n++;
+        }
+        if (n < 2) return null;
+
+        double covN = sxy - sx * sy / n;
+        double varX = sxx - sx * sx / n;
+        double varY = syy - sy * sy / n;
+        if (varX <= 0 || varY <= 0) return null;
+
+        double r = covN / Math.Sqrt(varX * varY);
+        double r2 = r * r;
+        return double.IsNaN(r2) ? null : r2;
+    }
+}

--- a/Dotsesses/Python/Violin/significance_matrix.py
+++ b/Dotsesses/Python/Violin/significance_matrix.py
@@ -162,6 +162,37 @@ def compute_cell_pvalue(
     return (_welch_anova_pvalue(valid_groups), excluded)
 
 
+def compute_significance_pvalues(
+    numeric_series: List[Tuple[str, Dict[str, float]]],
+    categorical_series: List[Tuple[str, Dict[str, str]]],
+    test_family: str = 'parametric',
+) -> List[Dict]:
+    """
+    Per (numeric, categorical) cell, group the numeric values by the
+    categorical subgroup over their common students and run the omnibus test
+    (same grouping as the matrix; see compute_cell_pvalue). Returns a flat list
+    of {'num', 'cat', 'p'} where 'p' is NaN when the cell is untestable.
+
+    A single call computes every cell, so the C# side can drive default
+    Significance selection at load time without rendering the matrix or making
+    one interop call per cell (ADR-0016).
+    """
+    results: List[Dict] = []
+    for num_name, num_data in numeric_series:
+        for cat_name, cat_data in categorical_series:
+            subgroup_to_values: Dict[str, List[float]] = {}
+            common_ids = set(cat_data.keys()) & set(num_data.keys())
+            for sid in common_ids:
+                subgroup_to_values.setdefault(cat_data[sid], []).append(num_data[sid])
+            p, _excluded = compute_cell_pvalue(subgroup_to_values, test_family)
+            results.append({
+                'num': num_name,
+                'cat': cat_name,
+                'p': float(p) if p is not None else float('nan'),
+            })
+    return results
+
+
 def _format_pvalue_annotation(p: Optional[float]) -> Tuple[str, bool]:
     """
     Build the in-cell annotation label and whether it is significant.

--- a/Dotsesses/Services/SignificancePlotService.cs
+++ b/Dotsesses/Services/SignificancePlotService.cs
@@ -86,4 +86,44 @@ public class SignificancePlotService
 
         return (svgContent, dataPoints);
     }
+
+    /// <summary>
+    /// Computes the per-cell omnibus p-value for every (numeric, categorical)
+    /// pair in a single Python call — no plot rendering. Used at load time to
+    /// drive the data-driven default Significance selection (see ADR-0016).
+    /// Returns a map keyed by (numericSeriesName, categoricalSeriesName); a
+    /// null value means the cell was untestable.
+    /// </summary>
+    public Dictionary<(string Num, string Cat), double?> ComputeCellPValues(
+        List<(string Name, Dictionary<string, double> Values)> numericSeries,
+        List<(string Name, Dictionary<string, string> Subgroups)> categoricalSeries,
+        SignificanceTestFamily testFamily = SignificanceTestFamily.Parametric)
+    {
+        var result = new Dictionary<(string Num, string Cat), double?>();
+        if (numericSeries.Count == 0 || categoricalSeries.Count == 0)
+        {
+            return result;
+        }
+
+        var pyNumeric = numericSeries
+            .Select(s => (s.Name, (IReadOnlyDictionary<string, double>)s.Values.AsReadOnly()))
+            .ToList();
+        var pyCategorical = categoricalSeries
+            .Select(s => (s.Name, (IReadOnlyDictionary<string, string>)s.Subgroups.AsReadOnly()))
+            .ToList();
+
+        var testFamilyStr = testFamily == SignificanceTestFamily.Nonparametric
+            ? "nonparametric"
+            : "parametric";
+
+        var rows = _module.ComputeSignificancePvalues(pyNumeric, pyCategorical, testFamilyStr);
+        foreach (var rowObj in rows)
+        {
+            var d = rowObj.As<IReadOnlyDictionary<string, PyObject>>();
+            var p = d["p"].As<double>();
+            result[(d["num"].As<string>(), d["cat"].As<string>())] =
+                double.IsNaN(p) ? null : p;
+        }
+        return result;
+    }
 }

--- a/Dotsesses/UI/MainWindowViewModel.cs
+++ b/Dotsesses/UI/MainWindowViewModel.cs
@@ -42,6 +42,9 @@ public partial class MainWindowViewModel : ViewModelBase
     private readonly HoverDelayService _hoverDelayService = null!;
     private readonly StateService _stateService = null!;
     private readonly WorkspaceFactory? _workspaceFactory;
+    // Used at load to compute data-driven default Significance selection
+    // (ADR-0016). Null in the test factory, which skips that refinement.
+    private readonly SignificancePlotService? _significancePlotService;
 
     /// <summary>
     /// Gets a fresh GradeAssigner built from the session's current
@@ -201,7 +204,8 @@ public partial class MainWindowViewModel : ViewModelBase
         SignificancePlotViewModel significancePlotViewModel,
         HoverDelayService hoverDelayService,
         StateService stateService,
-        WorkspaceFactory workspaceFactory)
+        WorkspaceFactory workspaceFactory,
+        SignificancePlotService significancePlotService)
     {
         Log("MainWindowViewModel: Constructor started");
 
@@ -212,6 +216,7 @@ public partial class MainWindowViewModel : ViewModelBase
         _hoverDelayService = hoverDelayService;
         _stateService = stateService;
         _workspaceFactory = workspaceFactory;
+        _significancePlotService = significancePlotService;
 
         // Create the tab container ViewModel
         _plotTabContainerViewModel = new PlotTabContainerViewModel(violinPlotViewModel, correlationPlotViewModel, significancePlotViewModel);
@@ -276,6 +281,7 @@ public partial class MainWindowViewModel : ViewModelBase
             null!,
             new HoverDelayService(),
             new StateService(),
+            null!,
             null!);
     }
 
@@ -1610,15 +1616,80 @@ public partial class MainWindowViewModel : ViewModelBase
         if (!ClassAssessment.Assessments.Any()) return;
 
         var firstStudent = ClassAssessment.Assessments.First();
-        ClassAssessment.ScoreSelections = ScoreSelectionDefaults.GenerateDefaults(
+        var baseDefaults = ScoreSelectionDefaults.GenerateDefaults(
             firstStudent.Scores,
             firstStudent.Attributes);
+
+        ClassAssessment.ScoreSelections = ApplyDataDrivenSelection(baseDefaults);
 
         var aggregateSet = BuildAggregateSet(ClassAssessment.ScoreSelections);
         foreach (var assessment in ClassAssessment.Assessments)
         {
             assessment.RecalculateAggregate(aggregateSet);
         }
+    }
+
+    /// <summary>
+    /// Pares the all-on base defaults down to a sensible per-plot subset
+    /// (ADR-0016): Distribution = Total + 10 leftmost numerics; Correlation =
+    /// the top-r² non-Total pairs + Total; Significance = categoricals with a
+    /// numeric at p≤0.2 plus their top-3 numerics. Only Display / Correlation /
+    /// Significance are rewritten; Type and Aggregate are preserved. The
+    /// Significance refinement is skipped (base flags kept) when the Python
+    /// service is unavailable (test factory).
+    /// </summary>
+    private IReadOnlyList<ScoreSelection> ApplyDataDrivenSelection(
+        IReadOnlyList<ScoreSelection> baseDefaults)
+    {
+        // Series name == the join key the plots/calculator use.
+        static string SeriesName(ScoreSelection s) =>
+            s.Index.HasValue ? $"{s.Name} {s.Index}" : s.Name;
+
+        var numericSel = baseDefaults.Where(s => s.Type == ScoreColumnType.Numeric).ToList();
+        var numericSeries = BuildSeriesData(ClassAssessment!, s => s.Type == ScoreColumnType.Numeric);
+        var categoricalSeries = BuildCategoricalSeriesData(ClassAssessment!, s => s.Type == ScoreColumnType.Categorical);
+
+        var orderedNumericNames = numericSeries.Select(s => s.SeriesName).ToList();
+        var totalName = numericSel
+            .Where(s => string.Equals(s.Name, "Total", StringComparison.OrdinalIgnoreCase) && s.Index == null)
+            .Select(SeriesName)
+            .FirstOrDefault();
+
+        var displayNames = PlotSelectionCalculator.SelectDistribution(orderedNumericNames, totalName);
+
+        var correlationInput = numericSeries
+            .Select(s => (s.SeriesName, (IReadOnlyDictionary<string, double>)s.Scores))
+            .ToList();
+        var correlationNames = PlotSelectionCalculator.SelectCorrelation(correlationInput, totalName);
+
+        // Significance needs per-cell p-values (Python). Skip the refinement
+        // when the service is absent — leave the base Significance flags.
+        HashSet<string>? significanceNames = null;
+        if (_significancePlotService != null && categoricalSeries.Count > 0)
+        {
+            var pvalues = _significancePlotService.ComputeCellPValues(
+                numericSeries.Select(s => (s.SeriesName, s.Scores)).ToList(),
+                categoricalSeries.Select(s => (s.SeriesName, s.Subgroups)).ToList(),
+                SignificanceTestFamily.Parametric);
+            significanceNames = PlotSelectionCalculator.SelectSignificance(
+                orderedNumericNames,
+                categoricalSeries.Select(s => s.SeriesName).ToList(),
+                (num, cat) => pvalues.TryGetValue((num, cat), out var p) ? p : null);
+        }
+
+        return baseDefaults.Select(s =>
+        {
+            var name = SeriesName(s);
+            bool isNumeric = s.Type == ScoreColumnType.Numeric;
+            return s with
+            {
+                Display = isNumeric ? displayNames.Contains(name) : s.Display,
+                Correlation = isNumeric && correlationNames.Contains(name),
+                Significance = significanceNames != null
+                    ? significanceNames.Contains(name)
+                    : s.Significance,
+            };
+        }).ToList();
     }
 
     /// <summary>

--- a/SPEC.md
+++ b/SPEC.md
@@ -174,6 +174,9 @@ with swarm overlay.
   to the C# side and rendered with an Avalonia shape overlay for
   hit-testing and hover effects.
 - One series per Score whose **Display** ScoreSelection flag is on.
+  **Default selection** (fresh load, see ADR-0016): the **Total** column
+  plus the first **10** non-Total numeric columns in left-to-right order
+  (≤ 11 series). Adjustable in Settings.
 - Hollow square for any Score with a Comment; filled circle otherwise.
 - Hover: highlights the same Student in every series and in the
   dotplot. Tooltip shows Score value and that Score's Comment. Each
@@ -198,9 +201,15 @@ with swarm overlay.
 
 Sibling tab in the bottom-right surface. Pearson correlation between
 every pair of Scores whose **Correlation** ScoreSelection flag is on.
-The user-defined AggregateScore deliberately does **not** appear in
-the matrix — correlating an aggregate against its own components would
-be misleading.
+No synthetic AggregateScore series is added to the matrix — correlating
+an aggregate against its own components would be misleading.
+
+**Default selection** (fresh load, see ADR-0016): the columns appearing
+in the **4 highest-r² pairs** among non-Total numerics, plus the **Total**
+column. (Total is excluded from the pair ranking — it tracks its
+components and would otherwise win every slot — but is included so the
+matrix opens with the overall-score column present.) The user can change
+this in Settings.
 
 ## Significance matrix
 
@@ -210,6 +219,12 @@ column with **Significance**=true, one column per StudentAttribute
 (Categorical) column with **Significance**=true. Each cell answers:
 *does subgroup membership in this categorical column materially shift
 the average of this numeric column?*
+
+**Default selection** (fresh load, see ADR-0016): using Welch's ANOVA
+p-values, a categorical column qualifies when its smallest p across the
+numerics is **≤ 0.2**; each qualifier brings in its **3 numerics with the
+smallest p**. The matrix opens on the union of qualifying categoricals and
+those numerics (empty matrix if none qualify). Adjustable in Settings.
 
 A plain-language guide for instructors — what the p-value means, the two
 test families, when to prefer each, and citations for papers — lives at

--- a/docs/adr/0016-data-driven-default-plot-selection.md
+++ b/docs/adr/0016-data-driven-default-plot-selection.md
@@ -1,0 +1,81 @@
+# Data-driven default column selection per plot
+
+`ScoreSelectionDefaults.GenerateDefaults` historically turned **every**
+column on for **every** plot (`Display` / `Correlation` / `Significance`
+all `true`). Real gradebooks carry 30–40+ columns, so each plot opened
+unreadably crowded. At fresh load we now pare the initial selection down
+to a sensible, data-driven subset per plot. The user can still change any
+of it in Settings; this only affects the *initial* seed, and only when
+selections are empty (`SeedDefaultSelectionsIfEmpty` already no-ops for
+loaded `.dots` files).
+
+## The three rules
+
+- **Distribution (`Display`)** — `Total` plus the first **10** non-Total
+  numeric columns in left-to-right (column) order. ≤ 11 series.
+- **Correlation (`Correlation`)** — Pearson **r²** for every pair of
+  non-Total numeric columns; the columns in the **4 highest-r² pairs**,
+  plus **Total**.
+- **Significance (`Significance`)** — Welch's ANOVA p-values per
+  (numeric, categorical) cell; a categorical *qualifies* if its smallest
+  p across numerics is **≤ 0.2**; each qualifier contributes its **3
+  smallest-p numerics**; the union of qualifying categoricals and those
+  numerics is selected.
+
+`Aggregate` is untouched (still every non-Total numeric; it drives the
+dotplot AggregateScore, independent of which plots show which columns).
+
+## Why these specific heuristics
+
+- **Total always in** Distribution and Correlation — it's the column
+  professors care about most; anchoring both plots on it is predictable.
+- **Total excluded from the r² ranking** — Total correlates strongly with
+  its own components, so including it would make all 4 top pairs
+  `Total × something` and crowd out the interesting inter-component
+  structure. Ranking the non-Total pairs surfaces that structure; Total is
+  then added back explicitly.
+- **p ≤ 0.2, top-3** for Significance — 0.2 is deliberately loose (this is
+  an *exploratory screening* default, not a significance claim — see
+  ADR-0015), wide enough to surface attributes worth a look; top-3 keeps
+  each qualifying categorical's column to a readable handful.
+- **Welch (parametric)** matches the matrix's default test family
+  (ADR-0015). The selection is computed once at load; the user can still
+  toggle the matrix's test family afterward without re-seeding.
+
+## Implementation notes
+
+- `Calculators/PlotSelectionCalculator.cs` is pure and keyed by *series
+  name* (the join key the plots already use), so the caller applies
+  results by recomputing each `ScoreSelection`'s series name. Pearson r²
+  is computed in C# (closed form, no new dependency).
+- Significance p-values reuse the existing `compute_cell_pvalue`
+  (ADR-0015) via a new one-shot Python helper
+  `compute_significance_pvalues` (surfaced as
+  `SignificancePlotService.ComputeCellPValues`) — one CSnakes call for the
+  whole grid instead of one per cell.
+- When the Python service is unavailable (the unit-test factory), the
+  Significance refinement is skipped and the base flags are kept; the pure
+  Distribution/Correlation rules still apply.
+
+## Considered alternatives
+
+- **Keep all-on defaults.** Simplest, but the crowding is the whole
+  problem.
+- **Include Total in the r² ranking.** Rejected — Total dominates.
+- **Return r² from the correlation render to C#** instead of computing
+  Pearson in C#. Rejected — couples selection to render and changes a
+  return contract; C# Pearson is trivial.
+- **One `ComputeCellPvalue` interop call per cell.** Rejected — hundreds
+  of boundary crossings at load; the batch helper is one call.
+
+## Consequences
+
+- Correlation now shows `Total` by default (it did not, in spirit,
+  before). SPEC's correlation note is reworded: no *synthetic*
+  AggregateScore series is added, but the Total column is selected by
+  default.
+- `MainWindowViewModel` gains a `SignificancePlotService` dependency (used
+  only at seed time).
+- Selection is now data-dependent, so default-selection tests assert
+  structural invariants (Total-always-in, ≤ 11 display, ≤ 9 correlation)
+  rather than all-true.


### PR DESCRIPTION
## Summary

Fresh loads previously turned **every** column on in **every** plot, so 30–40-column gradebooks opened unreadable. Each plot now seeds a sensible, data-driven subset (user-adjustable in Settings; saved `.dots` selections are untouched):

- **Distribution** — `Total` + the first **10** non-Total numerics in column order.
- **Correlation** — the columns in the **4 highest-r² non-Total pairs**, plus `Total` (Total is excluded from the ranking so it doesn't win every slot, then added).
- **Significance** — categoricals whose smallest **Welch** p across numerics is **≤ 0.2**, each with its **3 smallest-p numerics**; the union.

`Aggregate` is untouched (still drives the dotplot).

## How

- New pure `Calculators/PlotSelectionCalculator` — Pearson r² in C# (no dependency), keyed by series name so results map back to `ScoreSelection`.
- Significance p-values reuse `compute_cell_pvalue` (ADR-0015) via a new one-shot Python helper `compute_significance_pvalues`, surfaced as `SignificancePlotService.ComputeCellPValues` (one interop call for the whole grid).
- Wired into `SeedDefaultSelectionsIfEmpty`; the Significance refinement is skipped (base flags kept) when the Python service is absent (test factory).

## Tests / docs

11 calculator unit tests; the two default-selection VM tests updated to assert structural invariants (Total-always-in, ≤ 11 display, ≤ 9 correlation). **249/249 pass.** Docs: ADR-0016, SPEC.md, CONTEXT.md.

## Verification

Pure logic is unit-tested; the Python batch helper verified standalone. The full on-load result against a real 37-column file is best confirmed manually (open the three tabs).