### PR TITLE
fix(violin): center top-pinned tooltips on their series column

### DIFF
--- a/Dotsesses/UI/ViolinPlotControl.axaml.cs
+++ b/Dotsesses/UI/ViolinPlotControl.axaml.cs
@@ -648,10 +648,19 @@ public partial class ViolinPlotControl : UserControl
         // Get canvas width
         double canvasWidth = TooltipsOverlay.Bounds.Width;
 
-        // Position on left if too close to right edge, otherwise on right
-        double leftPos = displayX + 20 + tooltipWidth > canvasWidth
-            ? displayX - tooltipWidth - 20
-            : displayX + 20;
+        // Pinned-to-top tooltips are centered on their series column; beside-
+        // the-dot tooltips sit to the right (or left when near the right edge).
+        double leftPos = pinToTop
+            ? displayX - tooltipWidth / 2
+            : (displayX + 20 + tooltipWidth > canvasWidth
+                ? displayX - tooltipWidth - 20
+                : displayX + 20);
+
+        // Keep edge tooltips fully on-canvas.
+        if (canvasWidth > tooltipWidth)
+        {
+            leftPos = Math.Clamp(leftPos, 0, canvasWidth - tooltipWidth);
+        }
 
         Canvas.SetLeft(tooltipBorder, leftPos);
         // Many-series mode: pin to the top of the plot (still horizontally


### PR DESCRIPTION
When >10 score series push hover tooltips to the top of the Distribution plot, they were offset to the right of each dot. Center them on their series column instead (`displayX - width/2`), clamped to the canvas so the leftmost/rightmost stay fully visible. Beside-the-dot behavior (≤10 series) is unchanged.

Visual tweak to View code (no test seam); SPEC's "aligned to its series column" still holds.