### PR TITLE
feat(selection): exclude Grade/Grades from significance auto-select

### DIFF
--- a/Dotsesses.Tests/Calculators/PlotSelectionCalculatorTests.cs
+++ b/Dotsesses.Tests/Calculators/PlotSelectionCalculatorTests.cs
@@ -157,6 +157,28 @@ public class PlotSelectionCalculatorTests
     }
 
     [Fact]
+    public void SelectSignificance_ExcludesNamedCategoricals_CaseInsensitive()
+    {
+        var numerics = new[] { "Q1", "Q2" };
+        var cats = new[] { "Hat", "grade" };  // "grade" would otherwise qualify
+        var p = new Dictionary<(string, string), double?>
+        {
+            [("Q1", "Hat")] = 0.01,            // Hat qualifies via Q1 only
+            // Q2 × Hat omitted → untestable, so Hat doesn't pull Q2
+            [("Q1", "grade")] = 0.001, [("Q2", "grade")] = 0.002, // only "grade" reaches Q2
+        };
+
+        var result = PlotSelectionCalculator.SelectSignificance(
+            numerics, cats, (n, c) => p.TryGetValue((n, c), out var v) ? v : null,
+            excludedCategoricalNames: new[] { "Grade", "Grades" });
+
+        Assert.Contains("Hat", result);
+        Assert.Contains("Q1", result);
+        Assert.DoesNotContain("grade", result);   // excluded despite p well under threshold
+        Assert.DoesNotContain("Q2", result);       // only pulled in via the excluded categorical
+    }
+
+    [Fact]
     public void SelectSignificance_NoQualifiers_IsEmpty()
     {
         var result = PlotSelectionCalculator.SelectSignificance(

--- a/Dotsesses/Calculators/PlotSelectionCalculator.cs
+++ b/Dotsesses/Calculators/PlotSelectionCalculator.cs
@@ -98,21 +98,31 @@ public static class PlotSelectionCalculator
     /// <paramref name="threshold"/>; for each qualifier the
     /// <paramref name="topNumerics"/> numerics with the smallest p are added.
     /// Returns the union of qualifying categoricals and their selected numerics.
+    /// Categoricals named in <paramref name="excludedCategoricalNames"/>
+    /// (case-insensitive) are never auto-selected — e.g. a Grade column, which
+    /// is derived from the scores and would test as trivially significant.
     /// </summary>
     public static HashSet<string> SelectSignificance(
         IReadOnlyList<string> numericNames,
         IReadOnlyList<string> categoricalNames,
         Func<string, string, double?> pLookup,
         double threshold = 0.2,
-        int topNumerics = 3)
+        int topNumerics = 3,
+        IReadOnlyCollection<string>? excludedCategoricalNames = null)
     {
         ArgumentNullException.ThrowIfNull(numericNames);
         ArgumentNullException.ThrowIfNull(categoricalNames);
         ArgumentNullException.ThrowIfNull(pLookup);
 
+        var excluded = new HashSet<string>(
+            excludedCategoricalNames ?? Array.Empty<string>(),
+            StringComparer.OrdinalIgnoreCase);
+
         var result = new HashSet<string>(StringComparer.Ordinal);
         foreach (var cat in categoricalNames)
         {
+            if (excluded.Contains(cat)) continue;
+
             var ps = numericNames
                 .Select(n => (Name: n, P: pLookup(n, cat)))
                 .Where(t => t.P.HasValue)

--- a/Dotsesses/UI/MainWindowViewModel.cs
+++ b/Dotsesses/UI/MainWindowViewModel.cs
@@ -1674,7 +1674,11 @@ public partial class MainWindowViewModel : ViewModelBase
             significanceNames = PlotSelectionCalculator.SelectSignificance(
                 orderedNumericNames,
                 categoricalSeries.Select(s => s.SeriesName).ToList(),
-                (num, cat) => pvalues.TryGetValue((num, cat), out var p) ? p : null);
+                (num, cat) => pvalues.TryGetValue((num, cat), out var p) ? p : null,
+                // A Grade column is derived from the scores, so it would test as
+                // trivially significant — don't auto-select it (user can still
+                // enable it in Settings).
+                excludedCategoricalNames: new[] { "Grade", "Grades" });
         }
 
         return baseDefaults.Select(s =>

--- a/SPEC.md
+++ b/SPEC.md
@@ -224,7 +224,9 @@ the average of this numeric column?*
 p-values, a categorical column qualifies when its smallest p across the
 numerics is **≤ 0.2**; each qualifier brings in its **3 numerics with the
 smallest p**. The matrix opens on the union of qualifying categoricals and
-those numerics (empty matrix if none qualify). Adjustable in Settings.
+those numerics (empty matrix if none qualify). A **Grade**/**Grades**
+column is never auto-selected — it's derived from the scores and would
+test as trivially significant. Adjustable in Settings.
 
 A plain-language guide for instructors — what the p-value means, the two
 test families, when to prefer each, and citations for papers — lives at

--- a/docs/adr/0016-data-driven-default-plot-selection.md
+++ b/docs/adr/0016-data-driven-default-plot-selection.md
@@ -20,7 +20,10 @@ loaded `.dots` files).
   (numeric, categorical) cell; a categorical *qualifies* if its smallest
   p across numerics is **≤ 0.2**; each qualifier contributes its **3
   smallest-p numerics**; the union of qualifying categoricals and those
-  numerics is selected.
+  numerics is selected. A **Grade**/**Grades** categorical is excluded
+  from auto-selection (it's derived from the scores, so it tests as
+  trivially significant — same spirit as excluding Total from the
+  correlation ranking). The user can still enable it in Settings.
 
 `Aggregate` is untouched (still every non-Total numeric; it drives the
 dotplot AggregateScore, independent of which plots show which columns).


### PR DESCRIPTION
A `Grade`/`Grades` categorical column is derived from the scores, so every significance cell against it tests as trivially significant — the same reasoning that excludes `Total` from the correlation r² ranking (ADR-0016). It's no longer auto-selected on fresh load; the user can still enable it in Settings.

`SelectSignificance` gains an optional, case-insensitive `excludedCategoricalNames` parameter (calculator stays generic); the seeding wiring passes `{ "Grade", "Grades" }`. New unit test; ADR-0016 and SPEC.md updated. 250/250 pass.