### PR TITLE
feat(significance): Optimize button to re-pick numeric rows

### DIFF
--- a/Dotsesses.Tests/Calculators/PlotSelectionCalculatorTests.cs
+++ b/Dotsesses.Tests/Calculators/PlotSelectionCalculatorTests.cs
@@ -197,4 +197,47 @@ public class PlotSelectionCalculatorTests
             (_, _) => null);
         Assert.Empty(result);
     }
+
+    // ===== SelectTopCellNumerics (Optimize) =====
+
+    private static readonly Dictionary<(string, string), double?> OptimizeGrid = new()
+    {
+        [("Q1", "Hat")] = 0.01, [("Q2", "Hat")] = 0.30, [("Q3", "Hat")] = 0.04, [("Q4", "Hat")] = 0.50,
+        [("Q1", "Section")] = 0.02, [("Q2", "Section")] = 0.20, [("Q3", "Section")] = 0.90,
+        // (Q4, Section) omitted → untestable
+    };
+
+    private static double? OptimizeLookup(string n, string c) =>
+        OptimizeGrid.TryGetValue((n, c), out var v) ? v : null;
+
+    [Fact]
+    public void SelectTopCellNumerics_TakesNumericsOfLowestPCells_NoCategoricals()
+    {
+        // Sorted cells: (Q1,Hat).01, (Q1,Section).02, (Q3,Hat).04, ...
+        // Top 3 cells → numerics {Q1, Q3} (Q1 twice → distinct).
+        var result = PlotSelectionCalculator.SelectTopCellNumerics(
+            new[] { "Q1", "Q2", "Q3", "Q4" }, new[] { "Hat", "Section" }, OptimizeLookup, topCells: 3);
+
+        Assert.Equal(new HashSet<string> { "Q1", "Q3" }, result);
+        Assert.DoesNotContain("Hat", result);       // categoricals are never returned
+        Assert.DoesNotContain("Section", result);
+    }
+
+    [Fact]
+    public void SelectTopCellNumerics_FewerCellsThanN_ReturnsAllTestableNumerics()
+    {
+        var result = PlotSelectionCalculator.SelectTopCellNumerics(
+            new[] { "Q1", "Q2", "Q3", "Q4" }, new[] { "Hat", "Section" }, OptimizeLookup, topCells: 100);
+
+        // Every numeric has at least one testable cell.
+        Assert.Equal(new HashSet<string> { "Q1", "Q2", "Q3", "Q4" }, result);
+    }
+
+    [Fact]
+    public void SelectTopCellNumerics_AllUntestable_IsEmpty()
+    {
+        var result = PlotSelectionCalculator.SelectTopCellNumerics(
+            new[] { "Q1", "Q2" }, new[] { "Hat" }, (_, _) => null, topCells: 10);
+        Assert.Empty(result);
+    }
 }

--- a/Dotsesses/Calculators/PlotSelectionCalculator.cs
+++ b/Dotsesses/Calculators/PlotSelectionCalculator.cs
@@ -119,28 +119,76 @@ public static class PlotSelectionCalculator
             StringComparer.OrdinalIgnoreCase);
 
         var result = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var cat in categoricalNames)
+        foreach (var group in TestableCells(numericNames, categoricalNames, pLookup, excluded)
+                     .GroupBy(c => c.Cat))
         {
-            if (excluded.Contains(cat)) continue;
+            var cells = group.ToList();
+            if (cells.Min(c => c.P) > threshold) continue;  // no numeric near significant
 
-            var ps = numericNames
-                .Select(n => (Name: n, P: pLookup(n, cat)))
-                .Where(t => t.P.HasValue)
-                .Select(t => (t.Name, P: t.P!.Value))
-                .ToList();
-            if (ps.Count == 0) continue;
-            if (ps.Min(t => t.P) > threshold) continue;
-
-            result.Add(cat);
-            foreach (var t in ps
-                         .OrderBy(t => t.P)
-                         .ThenBy(t => t.Name, StringComparer.Ordinal)
+            result.Add(group.Key);
+            foreach (var c in cells
+                         .OrderBy(c => c.P)
+                         .ThenBy(c => c.Num, StringComparer.Ordinal)
                          .Take(topNumerics))
             {
-                result.Add(t.Name);
+                result.Add(c.Num);
             }
         }
         return result;
+    }
+
+    /// <summary>
+    /// Optimize selection: rank every testable (numeric × categorical) cell by
+    /// p ascending, take the <paramref name="topCells"/> lowest, and return the
+    /// distinct **numeric** names appearing in them. Categoricals are not
+    /// returned — the caller keeps the displayed categorical set fixed and only
+    /// re-picks the numeric rows. Shares the cell enumeration with
+    /// <see cref="SelectSignificance"/>.
+    /// </summary>
+    public static HashSet<string> SelectTopCellNumerics(
+        IReadOnlyList<string> numericNames,
+        IReadOnlyList<string> categoricalNames,
+        Func<string, string, double?> pLookup,
+        int topCells = 10,
+        IReadOnlyCollection<string>? excludedCategoricalNames = null)
+    {
+        ArgumentNullException.ThrowIfNull(numericNames);
+        ArgumentNullException.ThrowIfNull(categoricalNames);
+        ArgumentNullException.ThrowIfNull(pLookup);
+
+        var excluded = new HashSet<string>(
+            excludedCategoricalNames ?? Array.Empty<string>(),
+            StringComparer.OrdinalIgnoreCase);
+
+        return TestableCells(numericNames, categoricalNames, pLookup, excluded)
+            .OrderBy(c => c.P)
+            .ThenBy(c => c.Cat, StringComparer.Ordinal)
+            .ThenBy(c => c.Num, StringComparer.Ordinal)
+            .Take(topCells)
+            .Select(c => c.Num)
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Enumerates the testable (numeric × categorical) cells with a computable
+    /// p-value, skipping excluded categoricals. Shared by
+    /// <see cref="SelectSignificance"/> and <see cref="SelectTopCellNumerics"/>.
+    /// </summary>
+    private static IEnumerable<(string Num, string Cat, double P)> TestableCells(
+        IReadOnlyList<string> numericNames,
+        IReadOnlyList<string> categoricalNames,
+        Func<string, string, double?> pLookup,
+        ISet<string> excludedCategoricals)
+    {
+        foreach (var cat in categoricalNames)
+        {
+            if (excludedCategoricals.Contains(cat)) continue;
+            foreach (var num in numericNames)
+            {
+                var p = pLookup(num, cat);
+                if (p.HasValue) yield return (num, cat, p.Value);
+            }
+        }
     }
 
     /// <summary>

--- a/Dotsesses/UI/MainWindowViewModel.cs
+++ b/Dotsesses/UI/MainWindowViewModel.cs
@@ -213,6 +213,11 @@ public partial class MainWindowViewModel : ViewModelBase
         _violinPlotViewModel = violinPlotViewModel;
         _correlationPlotViewModel = correlationPlotViewModel;
         _significancePlotViewModel = significancePlotViewModel;
+        // null in the test factory; guarded so CreateForTesting stays valid.
+        if (significancePlotViewModel != null)
+        {
+            significancePlotViewModel.OptimizeRequested = OnOptimizeSignificance;
+        }
         _hoverDelayService = hoverDelayService;
         _stateService = stateService;
         _workspaceFactory = workspaceFactory;
@@ -1641,10 +1646,6 @@ public partial class MainWindowViewModel : ViewModelBase
     private IReadOnlyList<ScoreSelection> ApplyDataDrivenSelection(
         IReadOnlyList<ScoreSelection> baseDefaults)
     {
-        // Series name == the join key the plots/calculator use.
-        static string SeriesName(ScoreSelection s) =>
-            s.Index.HasValue ? $"{s.Name} {s.Index}" : s.Name;
-
         var numericSel = baseDefaults.Where(s => s.Type == ScoreColumnType.Numeric).ToList();
         var numericSeries = BuildSeriesData(ClassAssessment!, s => s.Type == ScoreColumnType.Numeric);
         var categoricalSeries = BuildCategoricalSeriesData(ClassAssessment!, s => s.Type == ScoreColumnType.Categorical);
@@ -1652,7 +1653,7 @@ public partial class MainWindowViewModel : ViewModelBase
         var orderedNumericNames = numericSeries.Select(s => s.SeriesName).ToList();
         var totalName = numericSel
             .Where(s => string.Equals(s.Name, "Total", StringComparison.OrdinalIgnoreCase) && s.Index == null)
-            .Select(SeriesName)
+            .Select(SeriesNameOf)
             .FirstOrDefault();
 
         var displayNames = PlotSelectionCalculator.SelectDistribution(orderedNumericNames, totalName);
@@ -1667,14 +1668,10 @@ public partial class MainWindowViewModel : ViewModelBase
         HashSet<string>? significanceNames = null;
         if (_significancePlotService != null && categoricalSeries.Count > 0)
         {
-            var pvalues = _significancePlotService.ComputeCellPValues(
-                numericSeries.Select(s => (s.SeriesName, s.Scores)).ToList(),
-                categoricalSeries.Select(s => (s.SeriesName, s.Subgroups)).ToList(),
-                SignificanceTestFamily.Parametric);
             significanceNames = PlotSelectionCalculator.SelectSignificance(
                 orderedNumericNames,
                 categoricalSeries.Select(s => s.SeriesName).ToList(),
-                (num, cat) => pvalues.TryGetValue((num, cat), out var p) ? p : null,
+                BuildSignificancePLookup(numericSeries, categoricalSeries, SignificanceTestFamily.Parametric),
                 // A Grade column is derived from the scores, so it would test as
                 // trivially significant — don't auto-select it (user can still
                 // enable it in Settings).
@@ -1683,7 +1680,7 @@ public partial class MainWindowViewModel : ViewModelBase
 
         return baseDefaults.Select(s =>
         {
-            var name = SeriesName(s);
+            var name = SeriesNameOf(s);
             bool isNumeric = s.Type == ScoreColumnType.Numeric;
             return s with
             {
@@ -1694,6 +1691,70 @@ public partial class MainWindowViewModel : ViewModelBase
                     : s.Significance,
             };
         }).ToList();
+    }
+
+    /// <summary>The series-name join key used by the plots and the selection
+    /// calculator: <c>"Name Index"</c> when indexed, else <c>"Name"</c>.</summary>
+    private static string SeriesNameOf(ScoreSelection s) =>
+        s.Index.HasValue ? $"{s.Name} {s.Index}" : s.Name;
+
+    /// <summary>
+    /// Builds a per-cell p-value lookup (numeric series name, categorical series
+    /// name) → p, by running the omnibus test for the given test family. Shared
+    /// by the load-time auto-select and the interactive Optimize. Returns an
+    /// all-null lookup when the Python service is unavailable.
+    /// </summary>
+    private Func<string, string, double?> BuildSignificancePLookup(
+        List<(string SeriesName, Dictionary<string, double> Scores)> numericSeries,
+        List<(string SeriesName, Dictionary<string, string> Subgroups)> categoricalSeries,
+        SignificanceTestFamily testFamily)
+    {
+        if (_significancePlotService == null || categoricalSeries.Count == 0)
+        {
+            return (_, _) => null;
+        }
+
+        var pvalues = _significancePlotService.ComputeCellPValues(
+            numericSeries.Select(s => (s.SeriesName, s.Scores)).ToList(),
+            categoricalSeries.Select(s => (s.SeriesName, s.Subgroups)).ToList(),
+            testFamily);
+        return (num, cat) => pvalues.TryGetValue((num, cat), out var p) ? p : null;
+    }
+
+    /// <summary>
+    /// Optimize the Significance Matrix: holding the currently-displayed
+    /// categorical columns fixed, rank every (numeric × displayed-categorical)
+    /// cell by p (using the matrix's current test family), take the 10
+    /// lowest-p cells, and set the matrix's numeric rows to the numerics in
+    /// them — replacing the current rows. Categoricals, Display, Correlation
+    /// and Aggregate are untouched. Invoked via the Optimize button on the
+    /// Significance plot (callback wired in the constructor).
+    /// </summary>
+    private void OnOptimizeSignificance()
+    {
+        if (ClassAssessment == null || _significancePlotService == null) return;
+
+        var numericSeries = BuildSeriesData(ClassAssessment, s => s.Type == ScoreColumnType.Numeric);
+        var categoricalSeries = BuildCategoricalSeriesData(
+            ClassAssessment, s => s.Significance && s.Type == ScoreColumnType.Categorical);
+        if (categoricalSeries.Count == 0) return; // nothing displayed to optimize against
+
+        var testFamily = SignificancePlotViewModel?.TestFamily ?? SignificanceTestFamily.Parametric;
+        var pLookup = BuildSignificancePLookup(numericSeries, categoricalSeries, testFamily);
+
+        var numericSet = PlotSelectionCalculator.SelectTopCellNumerics(
+            numericSeries.Select(s => s.SeriesName).ToList(),
+            categoricalSeries.Select(s => s.SeriesName).ToList(),
+            pLookup,
+            topCells: 10);
+
+        var newSelections = ClassAssessment.ScoreSelections.Select(s =>
+            s.Type == ScoreColumnType.Numeric
+                ? s with { Significance = numericSet.Contains(SeriesNameOf(s)) }
+                : s) // displayed categoricals stay selected; others stay as-is
+            .ToList();
+
+        ApplyScoreSelections(newSelections);
     }
 
     /// <summary>

--- a/Dotsesses/UI/SignificancePlotControl.axaml
+++ b/Dotsesses/UI/SignificancePlotControl.axaml
@@ -17,20 +17,30 @@
             <Canvas x:Name="PointsOverlay" Background="Transparent" />
         </Grid>
 
-        <!-- Controls overlay (top-right): per-cell test family selector. The
+        <!-- Controls overlay (top-right): test-family selector + Optimize. The
              matrix p-values are RAW / exploratory-screening (see ADR-0014). -->
-        <ComboBox x:Name="TestFamilyCombo"
-                  HorizontalAlignment="Right"
-                  VerticalAlignment="Top"
-                  Margin="0,0,8,0"
-                  MinWidth="0"
-                  FontSize="11"
-                  SelectedIndex="0"
-                  Opacity="0.9"
-                  SelectionChanged="OnTestFamilyChanged"
-                  ToolTip.Tip="Per-cell omnibus test. Parametric = Welch's ANOVA (reduces to Welch's t for 2 groups); Non-parametric = Kruskal–Wallis (reduces to Mann–Whitney). p-values are uncorrected — this is an exploratory screening view.">
-            <ComboBoxItem>Parametric</ComboBoxItem>
-            <ComboBoxItem>Non-parametric</ComboBoxItem>
-        </ComboBox>
+        <StackPanel HorizontalAlignment="Right"
+                    VerticalAlignment="Top"
+                    Orientation="Horizontal"
+                    Spacing="6"
+                    Margin="0,0,8,0">
+            <Button x:Name="OptimizeButton"
+                    FontSize="11"
+                    Padding="8,2"
+                    Opacity="0.9"
+                    Content="Optimize"
+                    Click="OnOptimizeClick"
+                    ToolTip.Tip="Re-pick the numeric rows to the 10 most significant (lowest-p) for the categorical columns currently shown, using the selected test family." />
+            <ComboBox x:Name="TestFamilyCombo"
+                      MinWidth="0"
+                      FontSize="11"
+                      SelectedIndex="0"
+                      Opacity="0.9"
+                      SelectionChanged="OnTestFamilyChanged"
+                      ToolTip.Tip="Per-cell omnibus test. Parametric = Welch's ANOVA (reduces to Welch's t for 2 groups); Non-parametric = Kruskal–Wallis (reduces to Mann–Whitney). p-values are uncorrected — this is an exploratory screening view.">
+                <ComboBoxItem>Parametric</ComboBoxItem>
+                <ComboBoxItem>Non-parametric</ComboBoxItem>
+            </ComboBox>
+        </StackPanel>
     </Grid>
 </UserControl>

--- a/Dotsesses/UI/SignificancePlotControl.axaml.cs
+++ b/Dotsesses/UI/SignificancePlotControl.axaml.cs
@@ -114,6 +114,15 @@ public partial class SignificancePlotControl : UserControl
     /// the current theme. No-ops when the selection already matches the VM
     /// (e.g. when the combo is being synced from the VM on load).
     /// </summary>
+    /// <summary>
+    /// Optimize button: ask the VM (→ MainWindowViewModel) to re-pick the most
+    /// significant numeric rows for the categoricals currently shown.
+    /// </summary>
+    private void OnOptimizeClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        (DataContext as SignificancePlotViewModel)?.RequestOptimize();
+    }
+
     private void OnTestFamilyChanged(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
     {
         if (DataContext is not SignificancePlotViewModel vm) return;

--- a/Dotsesses/UI/SignificancePlotViewModel.cs
+++ b/Dotsesses/UI/SignificancePlotViewModel.cs
@@ -53,6 +53,17 @@ public partial class SignificancePlotViewModel : ViewModelBase
     /// </summary>
     public IMessenger Messenger => _messenger;
 
+    /// <summary>
+    /// Invoked when the user clicks Optimize. Wired by MainWindowViewModel
+    /// (the single consumer that owns the selections — direct callback per
+    /// ADR-0004). Re-picks the matrix's numeric rows to the most significant
+    /// for the currently-displayed categoricals.
+    /// </summary>
+    public Action? OptimizeRequested { get; set; }
+
+    /// <summary>Raised from the Optimize button in the View code-behind.</summary>
+    public void RequestOptimize() => OptimizeRequested?.Invoke();
+
     public SignificancePlotViewModel(
         SignificancePlotService service,
         IMessenger messenger)

--- a/SPEC.md
+++ b/SPEC.md
@@ -270,6 +270,13 @@ test families, when to prefer each, and citations for papers — lives at
   workspace (SavedState v5; v4 files open as Parametric). The same family
   handles categorical columns with 2 or 2+ values — no group-count
   branching. Default: Parametric.
+- **Optimize button** (top-right, beside the selector): holding the
+  currently-shown **categorical** columns fixed, ranks every (numeric ×
+  shown-categorical) cell by p (using the selected test family), takes the
+  **10 lowest-p cells**, and sets the matrix's **numeric** rows to the
+  numerics in them — replacing the current rows. A quick way to collapse a
+  wide matrix to the strongest relationships for the attributes on screen.
+  Shares the p-value machinery with the load-time auto-select (ADR-0016).
 - **Small-N test policy**: subgroups with N<2 are dropped from the test
   (their dots still render); the cell is tested only if ≥2 valid subgroups
   remain, otherwise the annotation is `—`.

--- a/docs/adr/0016-data-driven-default-plot-selection.md
+++ b/docs/adr/0016-data-driven-default-plot-selection.md
@@ -82,3 +82,22 @@ dotplot AggregateScore, independent of which plots show which columns).
 - Selection is now data-dependent, so default-selection tests assert
   structural invariants (Total-always-in, ≤ 11 display, ≤ 9 correlation)
   rather than all-true.
+
+## Addendum: the Significance "Optimize" button
+
+An interactive **Optimize** button on the Significance plot reuses this
+machinery. Holding the currently-displayed categorical columns fixed, it
+ranks every (numeric × shown-categorical) cell by p — using the matrix's
+**current** test family (not always Welch) — takes the 10 lowest-p cells,
+and sets the numeric rows to the numerics in them (replacing the current
+rows). Shared code: `SignificancePlotService.ComputeCellPValues` (the
+p-grid), a private `TestableCells` cell-enumerator in
+`PlotSelectionCalculator` (used by both `SelectSignificance` and the new
+`SelectTopCellNumerics`), and a `BuildSignificancePLookup` helper +
+`ApplyScoreSelections` on `MainWindowViewModel`. The difference is the
+selection rule: auto-select qualifies categoricals (min p ≤ 0.2) and
+takes top-3 numerics each; Optimize takes a global top-10 cells over a
+fixed categorical set and returns only numerics. The button reaches
+`MainWindowViewModel` through a direct callback
+(`SignificancePlotViewModel.OptimizeRequested`) per ADR-0004
+(single consumer).


### PR DESCRIPTION
Adds an **Optimize** button to the Significance plot. Holding the currently-displayed categorical columns fixed, it ranks every (numeric × shown-categorical) cell by p using the matrix's **current** test family, takes the **10 lowest-p cells**, and sets the numeric rows to the numerics in them (replacing current rows) via `ApplyScoreSelections` — which leaves cursors/dotplot untouched (only `Significance` flips).

**Shared code** with the load-time auto-select (per request):
- new private `TestableCells` enumerator in `PlotSelectionCalculator`, used by both `SelectSignificance` and the new `SelectTopCellNumerics`
- `SignificancePlotService.ComputeCellPValues` (the p-grid)
- `BuildSignificancePLookup` + `SeriesNameOf` helpers on `MainWindowViewModel`

The button reaches `MainWindowViewModel` via a direct callback (`SignificancePlotViewModel.OptimizeRequested`) per ADR-0004 (single consumer).

3 new `SelectTopCellNumerics` unit tests; `SelectSignificance` unchanged after the refactor. **253/253 pass.** Docs: ADR-0016 addendum, SPEC.md.